### PR TITLE
Add getExisting (contract) to Driver

### DIFF
--- a/eth.ts
+++ b/eth.ts
@@ -53,6 +53,13 @@ export class Web3Driver{
             throw e;
         }
     }
+    
+    getExisting<N extends keyof Contracts>(contractName: N, contractAddress: string) {
+        const abi = compiledContracts[contractName].abi;
+        const web3Contract = new this.web3.eth.Contract(abi, contractAddress);
+        this.contracts.set(web3Contract.options.address, {web3Contract, name:contractName});
+        return new Contract(this, abi, web3Contract.options.address) as Contracts[N];
+    }
 
     async txTimestamp(r: TransactionReceipt): Promise<number> {
         return (await this.eth.getBlock(r.blockNumber)).timestamp as number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pos-v2",
+  "name": "@orbs-network/orbs-ethereum-contracts-v2",
   "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbs-network/orbs-ethereum-contracts-v2",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbs-network/orbs-ethereum-contracts-v2",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "./release/test/test-kit.js",
   "repository": "https://github.com/orbs-network/orbs-ethereum-contracts-v2",


### PR DESCRIPTION
support `getExisting` in driver for accessing contracts which are already deployed by their address


feature  requested by @talkol 