### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "truffle-hdwallet-provider": "1.0.3",
     "ts-retry-promise": "^0.2.0",
     "web3": "1.2.6",
-    "web3-core": "^1.2.6",
-    "web3-eth-contract": "^1.2.6"
+    "web3-core": "1.2.6",
+    "web3-eth-contract": "1.2.6"
   }
 }


### PR DESCRIPTION
Versions 1.2.7 were released and were matched, causing typescript to freak out due to unmatching versions. Let's hold these hard coded on 1.2.6 so all versions match
