### PR TITLE
ProtocolVersionChanged - event revised

### DIFF
--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -30,7 +30,7 @@ contract Protocol is IProtocol, Ownable {
         deploymentSubsets[deploymentSubset].fromTimestamp = now;
         deploymentSubsets[deploymentSubset].exists = true;
 
-        emit ProtocolVersionChanged(deploymentSubset, initialProtocolVersion, initialProtocolVersion, block.number); // TODO different event?
+        emit ProtocolVersionChanged(deploymentSubset, initialProtocolVersion, initialProtocolVersion, now); // TODO different event?
     }
 
     function setProtocolVersion(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external onlyOwner {

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -8,7 +8,7 @@ contract Protocol is IProtocol, Ownable {
     struct DeploymentSubset {
         bool exists;
         uint256 nextVersion;
-        uint asOfBlock;
+        uint fromTimestamp;
         uint256 currentVersion;
     }
 
@@ -27,31 +27,31 @@ contract Protocol is IProtocol, Ownable {
 
         deploymentSubsets[deploymentSubset].currentVersion = initialProtocolVersion;
         deploymentSubsets[deploymentSubset].nextVersion = initialProtocolVersion;
-        deploymentSubsets[deploymentSubset].asOfBlock = block.number;
+        deploymentSubsets[deploymentSubset].fromTimestamp = now;
         deploymentSubsets[deploymentSubset].exists = true;
 
         emit ProtocolVersionChanged(deploymentSubset, initialProtocolVersion, block.number); // TODO different event?
     }
 
-    function setProtocolVersion(string calldata deploymentSubset, uint256 protocolVersion, uint256 asOfBlock) external onlyOwner {
+    function setProtocolVersion(string calldata deploymentSubset, uint256 protocolVersion, uint256 fromTimestamp) external onlyOwner {
         require(deploymentSubsets[deploymentSubset].exists, "deployment subset does not exist");
-        require(asOfBlock > block.number, "protocol update can only be scheduled for a future block");
+        require(fromTimestamp > now, "a protocol update can only be scheduled for the future");
 
         (bool prevUpgradeExecuted, uint256 currentVersion) = checkPrevUpgrades(deploymentSubset);
 
         require(protocolVersion >= currentVersion, "protocol version must be greater or equal to current version");
 
         deploymentSubsets[deploymentSubset].nextVersion = protocolVersion;
-        deploymentSubsets[deploymentSubset].asOfBlock = asOfBlock;
+        deploymentSubsets[deploymentSubset].fromTimestamp = fromTimestamp;
         if (prevUpgradeExecuted) {
             deploymentSubsets[deploymentSubset].currentVersion = currentVersion;
         }
 
-        emit ProtocolVersionChanged(deploymentSubset, protocolVersion, asOfBlock);
+        emit ProtocolVersionChanged(deploymentSubset, protocolVersion, fromTimestamp);
     }
 
     function checkPrevUpgrades(string memory deploymentSubset) private view returns (bool prevUpgradeExecuted, uint256 currentVersion) {
-        prevUpgradeExecuted = deploymentSubsets[deploymentSubset].asOfBlock <= block.number;
+        prevUpgradeExecuted = deploymentSubsets[deploymentSubset].fromTimestamp <= now;
         currentVersion = prevUpgradeExecuted ? deploymentSubsets[deploymentSubset].nextVersion :
                                                deploymentSubsets[deploymentSubset].currentVersion;
     }

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -30,24 +30,24 @@ contract Protocol is IProtocol, Ownable {
         deploymentSubsets[deploymentSubset].fromTimestamp = now;
         deploymentSubsets[deploymentSubset].exists = true;
 
-        emit ProtocolVersionChanged(deploymentSubset, initialProtocolVersion, block.number); // TODO different event?
+        emit ProtocolVersionChanged(deploymentSubset, initialProtocolVersion, initialProtocolVersion, block.number); // TODO different event?
     }
 
-    function setProtocolVersion(string calldata deploymentSubset, uint256 protocolVersion, uint256 fromTimestamp) external onlyOwner {
+    function setProtocolVersion(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external onlyOwner {
         require(deploymentSubsets[deploymentSubset].exists, "deployment subset does not exist");
         require(fromTimestamp > now, "a protocol update can only be scheduled for the future");
 
         (bool prevUpgradeExecuted, uint256 currentVersion) = checkPrevUpgrades(deploymentSubset);
 
-        require(protocolVersion >= currentVersion, "protocol version must be greater or equal to current version");
+        require(nextVersion >= currentVersion, "protocol version must be greater or equal to current version");
 
-        deploymentSubsets[deploymentSubset].nextVersion = protocolVersion;
+        deploymentSubsets[deploymentSubset].nextVersion = nextVersion;
         deploymentSubsets[deploymentSubset].fromTimestamp = fromTimestamp;
         if (prevUpgradeExecuted) {
             deploymentSubsets[deploymentSubset].currentVersion = currentVersion;
         }
 
-        emit ProtocolVersionChanged(deploymentSubset, protocolVersion, fromTimestamp);
+        emit ProtocolVersionChanged(deploymentSubset, currentVersion, nextVersion, fromTimestamp);
     }
 
     function checkPrevUpgrades(string memory deploymentSubset) private view returns (bool prevUpgradeExecuted, uint256 currentVersion) {

--- a/contracts/spec_interfaces/IProtocol.sol
+++ b/contracts/spec_interfaces/IProtocol.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.5.16;
 
 interface IProtocol {
-    event ProtocolVersionChanged(string deploymentSubset, uint256 protocolVersion, uint256 asOfBlock);
+    event ProtocolVersionChanged(string deploymentSubset, uint256 protocolVersion, uint256 fromTimestamp);
 
     /*
      *   External methods
@@ -21,5 +21,5 @@ interface IProtocol {
     function createDeploymentSubset(string calldata deploymentSubset, uint256 initialProtocolVersion) external /* onlyOwner */;
 
     /// @dev schedules a protocol version upgrade for the given deployment subset.
-    function setProtocolVersion(string calldata deploymentSubset, uint256 protocolVersion, uint256 asOfBlock) external /* onlyOwner */;
+    function setProtocolVersion(string calldata deploymentSubset, uint256 protocolVersion, uint256 fromTimestamp) external /* onlyOwner */;
 }

--- a/contracts/spec_interfaces/IProtocol.sol
+++ b/contracts/spec_interfaces/IProtocol.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.5.16;
 
 interface IProtocol {
-    event ProtocolVersionChanged(string deploymentSubset, uint256 protocolVersion, uint256 fromTimestamp);
+    event ProtocolVersionChanged(string deploymentSubset, uint256 currentVersion, uint256 nextVersion, uint256 fromTimestamp);
 
     /*
      *   External methods
@@ -21,5 +21,5 @@ interface IProtocol {
     function createDeploymentSubset(string calldata deploymentSubset, uint256 initialProtocolVersion) external /* onlyOwner */;
 
     /// @dev schedules a protocol version upgrade for the given deployment subset.
-    function setProtocolVersion(string calldata deploymentSubset, uint256 protocolVersion, uint256 fromTimestamp) external /* onlyOwner */;
+    function setProtocolVersion(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external /* onlyOwner */;
 }

--- a/test/event-parsing.ts
+++ b/test/event-parsing.ts
@@ -54,7 +54,7 @@ export const vcConfigRecordChangedEvents = (txResult, contractAddress?: string) 
 export const vcOwnerChangedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, subscriptions, "VcOwnerChanged(uint256,address,address)", contractAddress);
 export const vcCreatedEvents = (txResult, contractAddress?: string): VcCreatedEvent[] => parseLogs(txResult, subscriptions, "VcCreated(uint256,address)", contractAddress);
 export const contractAddressUpdatedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, contractRegistry, "ContractAddressUpdated(string,address)", contractAddress);
-export const protocolChangedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, protocol, "ProtocolVersionChanged(string,uint256,uint256)", contractAddress);
+export const protocolChangedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, protocol, "ProtocolVersionChanged(string,uint256,uint256,uint256)", contractAddress);
 export const banningVoteEvents = (txResult, contractAddress?: string) => parseLogs(txResult, elections, "BanningVote(address,address[])", contractAddress);
 export const electionsBanned = (txResult, contractAddress?: string) => parseLogs(txResult, elections, "Banned(address)", contractAddress);
 export const electionsUnbanned = (txResult, contractAddress?: string) => parseLogs(txResult, elections, "Unbanned(address)", contractAddress);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,6 +2,7 @@ import Web3 from "web3";
 import BN from "bn.js";
 import * as _ from "lodash";
 import { Web3Driver } from "../eth";
+import {Driver} from "./driver";
 
 export const retry = (n: number, f: () => Promise<void>) => async  () => {
     for (let i = 0; i < n; i++) {
@@ -44,4 +45,15 @@ export function minAddress(addrs: string[]): string {
         .map(toBn)
         .reduce((m, x) => BN.min(m, x), toBn(addrs[0]));
     return addrs.find(addr => toBn(addr).eq(minBn)) as string
+}
+
+export async function getTopBlockTimestamp(d: Driver) : Promise<number> {
+    return new Promise(
+        (resolve, reject) =>
+            d.web3.eth.getBlock(
+                "latest",
+                (err, block: any) =>
+                    err ? reject(err): resolve(block.timestamp)
+            )
+    );
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -9,6 +9,11 @@ export const retry = (n: number, f: () => Promise<void>) => async  () => {
     }
 };
 
+export const evmIncreaseTimeForQueries = async (web3: Web3Driver, seconds: number) => {
+    await evmIncreaseTime(web3, seconds);
+    evmMine(web3, 1); // "bake" the new clock in by closing 1 block
+};
+
 export const evmIncreaseTime = async (web3: Web3Driver, seconds: number) => new Promise(
     (resolve, reject) =>
         (web3.currentProvider as any).send(

--- a/test/protocol.spec.ts
+++ b/test/protocol.spec.ts
@@ -78,11 +78,12 @@ describe('protocol-contract', async () => {
     await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 99);
   });
 
-  it('does not allow protocol upgrade to be scheduled in the past', async () => {
+  it('does not allow protocol upgrade to be scheduled in the past or now', async () => {
     const d = await Driver.new();
 
     const currTime: number = await getTopBlockTimestamp(d);
-    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime));
+    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime)); // fromTimestamps likely equal now
+    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime-1)); // fromTimestamps behind now
   });
 
   it('does not allow protocol downgrade', async () => {

--- a/test/protocol.spec.ts
+++ b/test/protocol.spec.ts
@@ -23,7 +23,7 @@ async function getTopBlockTimestamp(d: Driver) : Promise<number> {
   );
 }
 
-describe.only('protocol-contract', async () => {
+describe('protocol-contract', async () => {
 
   it('schedules a protocol version upgrade for the main, canary deployment subsets', async () => {
     const d = await Driver.new();

--- a/test/protocol.spec.ts
+++ b/test/protocol.spec.ts
@@ -10,18 +10,7 @@ chai.use(require('./matchers'));
 
 const expect = chai.expect;
 
-import {bn, evmIncreaseTimeForQueries} from "./helpers";
-
-async function getTopBlockTimestamp(d: Driver) : Promise<number> {
-  return new Promise(
-      (resolve, reject) =>
-          d.web3.eth.getBlock(
-              "latest",
-              (err, block: any) =>
-                  err ? reject(err): resolve(block.timestamp)
-          )
-  );
-}
+import {bn, evmIncreaseTimeForQueries, getTopBlockTimestamp} from "./helpers";
 
 describe('protocol-contract', async () => {
 

--- a/test/protocol.spec.ts
+++ b/test/protocol.spec.ts
@@ -10,117 +10,128 @@ chai.use(require('./matchers'));
 
 const expect = chai.expect;
 
-import {bn, evmMine, evmIncreaseTime} from "./helpers";
+import {bn, evmIncreaseTimeForQueries} from "./helpers";
 
-describe('protocol-contract', async () => {
+async function getTopBlockTimestamp(d: Driver) : Promise<number> {
+  return new Promise(
+      (resolve, reject) =>
+          d.web3.eth.getBlock(
+              "latest",
+              (err, block: any) =>
+                  err ? reject(err): resolve(block.timestamp)
+          )
+  );
+}
+
+describe.only('protocol-contract', async () => {
 
   it('schedules a protocol version upgrade for the main, canary deployment subsets', async () => {
     const d = await Driver.new();
 
-    const curBlockNumber: number = await new Promise((resolve, reject) => d.web3.eth.getBlockNumber((err, blockNumber) => err ? reject(err): resolve(blockNumber)));
-    let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, curBlockNumber + 100);
+    const currTime: number = await getTopBlockTimestamp(d);
+    let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 100);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
       protocolVersion: bn(2),
-      asOfBlock: bn(curBlockNumber + 100)
+      fromTimestamp: bn(currTime + 100)
     });
 
     r = await d.protocol.createDeploymentSubset(DEPLOYMENT_SUBSET_CANARY, 2);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_CANARY,
       protocolVersion: bn(2),
-      asOfBlock: bn(r.blockNumber)
+      fromTimestamp: bn(r.blockNumber)
     });
 
-    r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_CANARY, 3, curBlockNumber + 100);
+    r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_CANARY, 3, currTime + 100);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_CANARY,
       protocolVersion: bn(3),
-      asOfBlock: bn(curBlockNumber + 100)
+      fromTimestamp: bn(currTime + 100)
     });
   });
 
   it('does not allow protocol upgrade to be scheduled before the latest upgrade schedule when latest upgrade already took place', async () => {
     const d = await Driver.new();
 
-    const curBlockNumber: number = await new Promise((resolve, reject) => d.web3.eth.getBlockNumber((err, blockNumber) => err ? reject(err): resolve(blockNumber)));
-    let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, curBlockNumber + 3);
+    const currTime: number = await getTopBlockTimestamp(d);
+    let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 3);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
       protocolVersion: bn(2),
-      asOfBlock: bn(curBlockNumber + 3)
+      fromTimestamp: bn(currTime + 3)
     });
 
-    await evmMine(d.web3, 3);
+    await evmIncreaseTimeForQueries(d.web3, 3);
 
-    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, curBlockNumber + 3));
-    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, curBlockNumber + 2));
+    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 3));
+    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 2));
   });
 
   it('allows protocol upgrade to be scheduled before the latest upgrade schedule when latest upgrade did not yet take place', async () => {
     const d = await Driver.new();
 
-    const curBlockNumber: number = await new Promise((resolve, reject) => d.web3.eth.getBlockNumber((err, blockNumber) => err ? reject(err): resolve(blockNumber)));
-    let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, curBlockNumber + 100);
+    const currTime: number = await getTopBlockTimestamp(d);
+    let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 100);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
       protocolVersion: bn(2),
-      asOfBlock: bn(curBlockNumber + 100)
+      fromTimestamp: bn(currTime + 100)
     });
 
-    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 4, curBlockNumber + 100);
-    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, curBlockNumber + 99);
+    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 4, currTime + 100);
+    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 99);
   });
 
   it('does not allow protocol upgrade to be scheduled in the past', async () => {
     const d = await Driver.new();
 
-    const curBlockNumber: number = await new Promise((resolve, reject) => d.web3.eth.getBlockNumber((err, blockNumber) => err ? reject(err): resolve(blockNumber)));
-    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, curBlockNumber));
+    const currTime: number = await getTopBlockTimestamp(d);
+    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime));
   });
 
   it('does not allow protocol downgrade', async () => {
     const d = await Driver.new();
 
-    const curBlockNumber: number = await new Promise((resolve, reject) => d.web3.eth.getBlockNumber((err, blockNumber) => err ? reject(err): resolve(blockNumber)));
-    let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, curBlockNumber + 3);
+    const currTime: number = await getTopBlockTimestamp(d);
+    let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 3);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
       protocolVersion: bn(3),
-      asOfBlock: bn(curBlockNumber + 3)
+      fromTimestamp: bn(currTime + 3)
     });
 
-    await evmMine(d.web3, 3);
+    await evmIncreaseTimeForQueries(d.web3, 3);
 
-    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, curBlockNumber + 100));
+    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 100));
   });
 
   it('allows upgrading to current version (an abort mechanism)', async () => {
     const d = await Driver.new();
 
-    const curBlockNumber: number = await new Promise((resolve, reject) => d.web3.eth.getBlockNumber((err, blockNumber) => err ? reject(err): resolve(blockNumber)));
-    let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, curBlockNumber + 3);
+    const currTime: number = await getTopBlockTimestamp(d);
+    let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 3);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
       protocolVersion: bn(3),
-      asOfBlock: bn(curBlockNumber + 3)
+      fromTimestamp: bn(currTime + 3)
     });
 
-    await evmMine(d.web3, 3);
-    await evmMine(d.web3, 3);
+    await evmIncreaseTimeForQueries(d.web3, 3);
+    await evmIncreaseTimeForQueries(d.web3, 3);
 
-    r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 4, curBlockNumber + 100);
+    r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 4, currTime + 100);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
       protocolVersion: bn(4),
-      asOfBlock: bn(curBlockNumber + 100)
+      fromTimestamp: bn(currTime + 100)
     });
 
-    r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, curBlockNumber + 50);
+    r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 50);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
       protocolVersion: bn(3),
-      asOfBlock: bn(curBlockNumber + 50)
+      fromTimestamp: bn(currTime + 50)
     });
   });
 
@@ -131,25 +142,25 @@ describe('protocol-contract', async () => {
     expect(reportedVersion).to.be.bignumber.equal(bn(1));
 
     // first upgrade
-    let curBlockNumber: number = await new Promise((resolve, reject) => d.web3.eth.getBlockNumber((err, blockNumber) => err ? reject(err): resolve(blockNumber)));
-    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, curBlockNumber + 3);
+    let currTime: number = await getTopBlockTimestamp(d);
+    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 3);
 
     reportedVersion = await d.protocol.getProtocolVersion(DEPLOYMENT_SUBSET_MAIN);
     expect(reportedVersion).to.be.bignumber.equal(bn(1));
 
-    await evmMine(d.web3, 3);
+    await evmIncreaseTimeForQueries(d.web3, 3);
 
     reportedVersion = await d.protocol.getProtocolVersion(DEPLOYMENT_SUBSET_MAIN);
     expect(reportedVersion).to.be.bignumber.equal(bn(2));
 
     // the second upgrade
-    curBlockNumber = await new Promise((resolve, reject) => d.web3.eth.getBlockNumber((err, blockNumber) => err ? reject(err): resolve(blockNumber)));
-    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, curBlockNumber + 3);
+    currTime = await getTopBlockTimestamp(d);
+    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 3);
 
     reportedVersion = await d.protocol.getProtocolVersion(DEPLOYMENT_SUBSET_MAIN);
     expect(reportedVersion).to.be.bignumber.equal(bn(2));
 
-    await evmMine(d.web3, 6);
+    await evmIncreaseTimeForQueries(d.web3, 6);
 
     reportedVersion = await d.protocol.getProtocolVersion(DEPLOYMENT_SUBSET_MAIN);
     expect(reportedVersion).to.be.bignumber.equal(bn(3));
@@ -159,8 +170,8 @@ describe('protocol-contract', async () => {
   it('distinguishes between different deployment subsets when calling getProtocolVersion', async () => {
     const d = await Driver.new();
 
-    const curBlockNumber: number = await new Promise((resolve, reject) => d.web3.eth.getBlockNumber((err, blockNumber) => err ? reject(err): resolve(blockNumber)));
-    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, curBlockNumber + 100);
+    const currTime: number = await getTopBlockTimestamp(d);
+    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 100);
 
     // future upgrade should not affect the current version
     let reportedVersionMain = await d.protocol.getProtocolVersion(DEPLOYMENT_SUBSET_MAIN);
@@ -176,7 +187,7 @@ describe('protocol-contract', async () => {
     reportedVersionMain = await d.protocol.getProtocolVersion(DEPLOYMENT_SUBSET_MAIN);
     expect(reportedVersionMain).to.be.bignumber.equal(bn(1));
 
-    await evmMine(d.web3, 100); // upgrade of DEPLOYMENT_SUBSET_MAIN kicks in
+    await evmIncreaseTimeForQueries(d.web3, 100); // upgrade of DEPLOYMENT_SUBSET_MAIN kicks in
 
     reportedVersionMain = await d.protocol.getProtocolVersion(DEPLOYMENT_SUBSET_MAIN);
     expect(reportedVersionMain).to.be.bignumber.equal(bn(2));

--- a/test/protocol.spec.ts
+++ b/test/protocol.spec.ts
@@ -21,21 +21,24 @@ describe('protocol-contract', async () => {
     let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 100);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
-      protocolVersion: bn(2),
+      currentVersion: bn(1),
+      nextVersion: bn(2),
       fromTimestamp: bn(currTime + 100)
     });
 
     r = await d.protocol.createDeploymentSubset(DEPLOYMENT_SUBSET_CANARY, 2);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_CANARY,
-      protocolVersion: bn(2),
+      currentVersion: bn(2),
+      nextVersion: bn(2),
       fromTimestamp: bn(r.blockNumber)
     });
 
     r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_CANARY, 3, currTime + 100);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_CANARY,
-      protocolVersion: bn(3),
+      currentVersion: bn(2),
+      nextVersion: bn(3),
       fromTimestamp: bn(currTime + 100)
     });
   });
@@ -47,7 +50,8 @@ describe('protocol-contract', async () => {
     let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 3);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
-      protocolVersion: bn(2),
+      currentVersion: bn(1),
+      nextVersion: bn(2),
       fromTimestamp: bn(currTime + 3)
     });
 
@@ -64,7 +68,8 @@ describe('protocol-contract', async () => {
     let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 100);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
-      protocolVersion: bn(2),
+      currentVersion: bn(1),
+      nextVersion: bn(2),
       fromTimestamp: bn(currTime + 100)
     });
 
@@ -86,7 +91,8 @@ describe('protocol-contract', async () => {
     let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 3);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
-      protocolVersion: bn(3),
+      currentVersion: bn(1),
+      nextVersion: bn(3),
       fromTimestamp: bn(currTime + 3)
     });
 
@@ -102,24 +108,26 @@ describe('protocol-contract', async () => {
     let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 3);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
-      protocolVersion: bn(3),
+      currentVersion: bn(1),
+      nextVersion: bn(3),
       fromTimestamp: bn(currTime + 3)
     });
 
-    await evmIncreaseTimeForQueries(d.web3, 3);
     await evmIncreaseTimeForQueries(d.web3, 3);
 
     r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 4, currTime + 100);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
-      protocolVersion: bn(4),
+      currentVersion: bn(3),
+      nextVersion: bn(4),
       fromTimestamp: bn(currTime + 100)
     });
 
     r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 3, currTime + 50);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
-      protocolVersion: bn(3),
+      currentVersion: bn(3),
+      nextVersion: bn(3),
       fromTimestamp: bn(currTime + 50)
     });
   });

--- a/test/protocol.spec.ts
+++ b/test/protocol.spec.ts
@@ -17,7 +17,7 @@ describe('protocol-contract', async () => {
   it('schedules a protocol version upgrade for the main, canary deployment subsets', async () => {
     const d = await Driver.new();
 
-    const currTime: number = await getTopBlockTimestamp(d);
+    let currTime: number = await getTopBlockTimestamp(d);
     let r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 100);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_MAIN,
@@ -27,11 +27,12 @@ describe('protocol-contract', async () => {
     });
 
     r = await d.protocol.createDeploymentSubset(DEPLOYMENT_SUBSET_CANARY, 2);
+    currTime = await getTopBlockTimestamp(d);
     expect(r).to.have.a.protocolChangedEvent({
       deploymentSubset: DEPLOYMENT_SUBSET_CANARY,
       currentVersion: bn(2),
       nextVersion: bn(2),
-      fromTimestamp: bn(r.blockNumber)
+      fromTimestamp: bn(currTime) // assuming ganache will not mine since last tx
     });
 
     r = await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_CANARY, 3, currTime + 100);

--- a/typings/protocol-contract.d.ts
+++ b/typings/protocol-contract.d.ts
@@ -4,13 +4,14 @@ import * as BN from "bn.js";
 
 export interface ProtocolChangedEvent {
   deploymentSubset: string,
-  protocolVersion: number,
+  currentVersion: number,
+  nextVersion: number,
   fromTimestamp: number
 }
 
 export interface ProtocolContract extends Contract {
   createDeploymentSubset(deploymentSubset: string, initialProtocolVersion: number, params?: TransactionConfig): Promise<TransactionReceipt>;
-  setProtocolVersion(deploymentSubset: string, protocolVersion: number, fromTimestamp: number,params?: TransactionConfig): Promise<TransactionReceipt>;
+  setProtocolVersion(deploymentSubset: string, nextVersion: number, fromTimestamp: number,params?: TransactionConfig): Promise<TransactionReceipt>;
   getProtocolVersion(deploymentSubset: string ,params?: TransactionConfig): Promise<BN>;
   deploymentSubsetExists(deploymentSubset: string, params?: TransactionConfig): Promise<boolean>;
 }

--- a/typings/protocol-contract.d.ts
+++ b/typings/protocol-contract.d.ts
@@ -5,12 +5,12 @@ import * as BN from "bn.js";
 export interface ProtocolChangedEvent {
   deploymentSubset: string,
   protocolVersion: number,
-  asOfBlock: number
+  fromTimestamp: number
 }
 
 export interface ProtocolContract extends Contract {
   createDeploymentSubset(deploymentSubset: string, initialProtocolVersion: number, params?: TransactionConfig): Promise<TransactionReceipt>;
-  setProtocolVersion(deploymentSubset: string, protocolVersion: number, asOfBlock: number,params?: TransactionConfig): Promise<TransactionReceipt>;
+  setProtocolVersion(deploymentSubset: string, protocolVersion: number, fromTimestamp: number,params?: TransactionConfig): Promise<TransactionReceipt>;
   getProtocolVersion(deploymentSubset: string ,params?: TransactionConfig): Promise<BN>;
   deploymentSubsetExists(deploymentSubset: string, params?: TransactionConfig): Promise<boolean>;
 }


### PR DESCRIPTION
resolves #53

- change protocol version upgrade schedule to be reference time based rather than block number
- add current version to the event

- still not addressing finality concerns because doubt was raised (@vistra) if it's needed. 