### PR TITLE
REWARDS: compact events, better remainder handling

### DIFF
--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -92,36 +92,32 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
     function _assignRewardsToCommittee(address[] memory committee, uint256[] memory committeeWeights, bool[] memory compliance) private {
         BootstrapAndStaking memory pools = bootstrapAndStaking;
 
-        uint48[] memory bootstrapRewards = collectBootstrapRewards(committee, compliance, pools);
-        uint48[] memory fees = collectFees(committee, compliance);
+        (uint48 generalValidatorBootstrap, uint48 certifiedValidatorBootstrap) = collectBootstrapRewards(committee, pools);
+        (uint48 generalValidatorFee, uint48 certifiedValidatorFee) = collectFees(committee, compliance);
         uint48[] memory stakingRewards = collectStakingRewards(committee, committeeWeights, pools);
 
         Balance memory balance;
         for (uint i = 0; i < committee.length; i++) {
             balance = balances[committee[i]];
-            balance.bootstrapRewards = uint48(balance.bootstrapRewards.add(bootstrapRewards[i])); // todo may overflow
-            balance.fees = uint48(balance.fees.add(fees[i])); // todo may overflow
-            balance.stakingRewards = uint48(balance.stakingRewards.add(stakingRewards[i])); // todo may overflow
+
+            balance.bootstrapRewards += (compliance[i] ? certifiedValidatorBootstrap : generalValidatorBootstrap); // todo may overflow
+            balance.fees += (compliance[i] ? certifiedValidatorFee : generalValidatorFee); // todo may overflow
+            balance.stakingRewards += stakingRewards[i]; // todo may overflow
+
             balances[committee[i]] = balance;
         }
         emit StakingRewardsAssigned(committee, stakingRewards);
-        emit BootstrapRewardsAssigned(committee, bootstrapRewards);
-        emit FeesAssigned(committee, fees);
+        emit BootstrapRewardsAssigned(toUint256Granularity(generalValidatorBootstrap), toUint256Granularity(certifiedValidatorBootstrap));
+        emit FeesAssigned(toUint256Granularity(generalValidatorFee), toUint256Granularity(certifiedValidatorFee));
 
         lastAssignedAt = now;
     }
 
-    function collectBootstrapRewards(address[] memory committee, bool[] memory compliance, BootstrapAndStaking memory pools) private view returns (uint48[] memory assignedRewards){
-        assignedRewards = new uint48[](committee.length);
-
+    function collectBootstrapRewards(address[] memory committee, BootstrapAndStaking memory pools) private view returns (uint48 generalValidatorBootstrap, uint48 certifiedValidatorBootstrap){
         if (committee.length > 0) {
             uint256 duration = now.sub(lastAssignedAt);
-            uint48 amountPerGeneralValidator = uint48(pools.generalCommitteeAnnualBootstrap.mul(duration).div(365 days));
-            uint48 amountPerCompliantValidator = uint48(pools.complianceCommitteeAnnualBootstrap.mul(duration).div(365 days));
-
-            for (uint i = 0; i < committee.length; i++) {
-                assignedRewards[i] = uint48(amountPerGeneralValidator + (compliance[i] ? amountPerCompliantValidator : 0)); // todo may overflow
-            }
+            generalValidatorBootstrap = uint48(pools.generalCommitteeAnnualBootstrap.mul(duration).div(365 days));
+            certifiedValidatorBootstrap = generalValidatorBootstrap + uint48(pools.complianceCommitteeAnnualBootstrap.mul(duration).div(365 days));
         }
     }
 
@@ -241,7 +237,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
 
     uint constant MAX_FEE_BUCKET_ITERATIONS = 6;
 
-    function collectFees(address[] memory committee, bool[] memory compliance) private returns (uint48[] memory assignedFees){
+    function collectFees(address[] memory committee, bool[] memory compliance) private returns (uint48 generalValidatorFee, uint48 certifiedValidatorFee) {
         // TODO we often do integer division for rate related calculation, which floors the result. Do we need to address this?
         // TODO for an empty committee or a committee with 0 total stake the divided amounts will be locked in the contract FOREVER
 
@@ -282,12 +278,11 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
             bucketsPayed++;
         }
 
-        assignedFees = new uint48[](committee.length);
-        assignFees(committee, compliance, generalFeePoolAmount, false, assignedFees);
-        assignFees(committee, compliance, complianceFeePoolAmount, true, assignedFees);
+        generalValidatorFee = divideFees(committee, compliance, generalFeePoolAmount, false);
+        certifiedValidatorFee = generalValidatorFee + divideFees(committee, compliance, complianceFeePoolAmount, true);
     }
 
-    function assignFees(address[] memory committee, bool[] memory compliance, uint256 amount, bool isCompliant, uint48[] memory assignedFees) private {
+    function divideFees(address[] memory committee, bool[] memory compliance, uint256 amount, bool isCompliant) private returns (uint48 validatorFee) {
         uint n = committee.length;
         if (isCompliant)  {
             n = 0; // todo - this is calculated in other places, get as argument to save gas
@@ -295,18 +290,11 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
                 if (compliance[i]) n++;
             }
         }
-        if (n == 0) return;
-
-        uint48 totalAssigned = 0;
-        uint48 curAmount = toUint48Granularity(amount.div(n));
-        for (uint i = 0; i < committee.length; i++) {
-            if (!isCompliant || compliance[i]) {
-                assignedFees[i] = uint48(assignedFees[i].add(curAmount)); // todo may overflow
-                totalAssigned = uint48(totalAssigned.add(curAmount));
-            }
+        if (n > 0) {
+            validatorFee = toUint48Granularity(amount.div(n));
         }
 
-        uint48 remainder = toUint48Granularity(amount.sub(toUint256Granularity(totalAssigned)));
+        uint48 remainder = toUint48Granularity(amount.sub(toUint256Granularity(validatorFee).mul(n)));
         if (remainder > 0) {
             fillFeeBucket(_bucketTime(now), remainder, isCompliant);
         }

--- a/contracts/interfaces/IRewards.sol
+++ b/contracts/interfaces/IRewards.sol
@@ -33,7 +33,8 @@ interface IRewards {
 
     // fees
 
-    event FeesAssigned(address[] assignees, uint48[] orbs_amounts);
+    event FeesAssigned(uint256 generalValidatorAmount, uint256 certifiedValidatorAmount);
+
     event FeesWithdrawnFromBucket(uint256 bucketId, uint256 withdrawn, uint256 total, bool isCompliant);
     event FeesAddedToBucket(uint256 bucketId, uint256 added, uint256 total, bool isCompliant);
 
@@ -57,7 +58,7 @@ interface IRewards {
 
     // bootstrap
 
-    event BootstrapRewardsAssigned(address[] assignees, uint48[] amounts);
+    event BootstrapRewardsAssigned(uint256 generalValidatorAmount, uint256 certifiedValidatorAmount);
     event BootstrapAddedToPool(uint256 added, uint256 total);
 
     /*

--- a/contracts/interfaces/IRewards.sol
+++ b/contracts/interfaces/IRewards.sol
@@ -12,7 +12,7 @@ interface IRewards {
     // staking
 
     event StakingRewardsDistributed(address indexed distributer, uint256 fromBlock, uint256 toBlock, uint split, uint txIndex, address[] to, uint256[] amounts);
-    event StakingRewardsAssigned(address[] assignees, uint48[] amounts); // todo balance?
+    event StakingRewardsAssigned(address[] assignees, uint256[] amounts); // todo balance?
 
     /// @return Returns the currently unclaimed orbs token reward balance of the given address.
     function getStakingRewardBalance(address addr) external view returns (uint256 balance);

--- a/contracts/interfaces/IRewards.sol
+++ b/contracts/interfaces/IRewards.sol
@@ -34,6 +34,7 @@ interface IRewards {
     // fees
 
     event FeesAssigned(address[] assignees, uint48[] orbs_amounts);
+    event FeesWithdrawnFromBucket(uint256 bucketId, uint256 withdrawn, uint256 total, bool isCompliant);
     event FeesAddedToBucket(uint256 bucketId, uint256 added, uint256 total, bool isCompliant);
 
     /*

--- a/test/bootstrap-rewards.spec.ts
+++ b/test/bootstrap-rewards.spec.ts
@@ -24,7 +24,7 @@ async function sleep(ms): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe.only('bootstrap-rewards-level-flows', async () => {
+describe('bootstrap-rewards-level-flows', async () => {
 
   it('should distribute bootstrap rewards to validators in committee', async () => {
     const d = await Driver.new({maxCommitteeSize: 4});

--- a/test/bootstrap-rewards.spec.ts
+++ b/test/bootstrap-rewards.spec.ts
@@ -24,7 +24,7 @@ async function sleep(ms): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe('bootstrap-rewards-level-flows', async () => {
+describe.only('bootstrap-rewards-level-flows', async () => {
 
   it('should distribute bootstrap rewards to validators in committee', async () => {
     const d = await Driver.new({maxCommitteeSize: 4});

--- a/test/event-parsing.ts
+++ b/test/event-parsing.ts
@@ -42,7 +42,7 @@ export const subscriptionChangedEvents = (txResult, contractAddress?: string): S
 export const paymentEvents = (txResult, contractAddress?: string) => parseLogs(txResult, subscriptions, "Payment(uint256,address,uint256,string,uint256)", contractAddress);
 export const feesAddedToBucketEvents = (txResult, contractAddress?: string): FeesAddedToBucketEvent[] => parseLogs(txResult, rewards, "FeesAddedToBucket(uint256,uint256,uint256,bool)", contractAddress);
 export const feesWithdrawnFromBucketEvents = (txResult, contractAddress?: string): FeesWithdrawnFromBucketEvent[] => parseLogs(txResult, rewards, "FeesWithdrawnToBucket(uint256,uint256,uint256,bool)", contractAddress);
-export const stakingRewardsAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "StakingRewardsAssigned(address[],uint48[])", contractAddress);
+export const stakingRewardsAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "StakingRewardsAssigned(address[],uint256[])", contractAddress);
 export const stakingRewardsDistributed = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "StakingRewardsDistributed(address,uint256,uint256,uint256,uint256,address[],uint256[])", contractAddress);
 export const feesAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "FeesAssigned(uint256,uint256)", contractAddress);
 export const bootstrapRewardsAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "BootstrapRewardsAssigned(uint256,uint256)", contractAddress);

--- a/test/event-parsing.ts
+++ b/test/event-parsing.ts
@@ -2,7 +2,7 @@ import Web3 from "web3";
 import * as _ from "lodash";
 import {SubscriptionChangedEvent, VcCreatedEvent} from "../typings/subscriptions-contract";
 import {compiledContracts} from "../compiled-contracts";
-import {FeesAddedToBucketEvent} from "../typings/rewards-contract";
+import {FeesAddedToBucketEvent, FeesWithdrawnFromBucketEvent} from "../typings/rewards-contract";
 
 const elections = compiledContracts["Elections"];
 const committee = compiledContracts["Committee"];
@@ -41,6 +41,7 @@ export const stakeChangedEvents = (txResult, contractAddress?: string) => parseL
 export const subscriptionChangedEvents = (txResult, contractAddress?: string): SubscriptionChangedEvent[] => parseLogs(txResult, subscriptions, "SubscriptionChanged(uint256,uint256,uint256,string,string)", contractAddress);
 export const paymentEvents = (txResult, contractAddress?: string) => parseLogs(txResult, subscriptions, "Payment(uint256,address,uint256,string,uint256)", contractAddress);
 export const feesAddedToBucketEvents = (txResult, contractAddress?: string): FeesAddedToBucketEvent[] => parseLogs(txResult, rewards, "FeesAddedToBucket(uint256,uint256,uint256,bool)", contractAddress);
+export const feesWithdrawnFromBucketEvents = (txResult, contractAddress?: string): FeesWithdrawnFromBucketEvent[] => parseLogs(txResult, rewards, "FeesWithdrawnToBucket(uint256,uint256,uint256,bool)", contractAddress);
 export const stakingRewardsAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "StakingRewardsAssigned(address[],uint48[])", contractAddress);
 export const stakingRewardsDistributed = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "StakingRewardsDistributed(address,uint256,uint256,uint256,uint256,address[],uint256[])", contractAddress);
 export const feesAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "FeesAssigned(address[],uint48[])", contractAddress);

--- a/test/event-parsing.ts
+++ b/test/event-parsing.ts
@@ -44,8 +44,8 @@ export const feesAddedToBucketEvents = (txResult, contractAddress?: string): Fee
 export const feesWithdrawnFromBucketEvents = (txResult, contractAddress?: string): FeesWithdrawnFromBucketEvent[] => parseLogs(txResult, rewards, "FeesWithdrawnToBucket(uint256,uint256,uint256,bool)", contractAddress);
 export const stakingRewardsAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "StakingRewardsAssigned(address[],uint48[])", contractAddress);
 export const stakingRewardsDistributed = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "StakingRewardsDistributed(address,uint256,uint256,uint256,uint256,address[],uint256[])", contractAddress);
-export const feesAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "FeesAssigned(address[],uint48[])", contractAddress);
-export const bootstrapRewardsAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "BootstrapRewardsAssigned(address[],uint48[])", contractAddress);
+export const feesAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "FeesAssigned(uint256,uint256)", contractAddress);
+export const bootstrapRewardsAssignedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "BootstrapRewardsAssigned(uint256,uint256)", contractAddress);
 export const bootstrapAddedToPoolEvents = (txResult, contractAddress?: string) => parseLogs(txResult, rewards, "BootstrapAddedToPool(uint256,uint256)", contractAddress);
 export const voteOutEvents = (txResult, contractAddress?: string) => parseLogs(txResult, elections, "VoteOut(address,address)", contractAddress);
 export const votedOutOfCommitteeEvents = (txResult, contractAddress?: string) => parseLogs(txResult, elections, "VotedOutOfCommittee(address)", contractAddress);

--- a/test/fees.spec.ts
+++ b/test/fees.spec.ts
@@ -25,7 +25,7 @@ async function sleep(ms): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe('fees-contract', async () => {
+describe.only('fees-contract', async () => {
 
   it('should distribute fees to validators in general and compliance committees', async () => {
     const d = await Driver.new({maxCommitteeSize: 4});
@@ -56,7 +56,7 @@ describe('fees-contract', async () => {
       const vcid = vcCreatedEvents(r)[0].vcid;
       let startTime = await txTimestamp(d.web3, r);
 
-      const feeBuckets = feesAddedToBucketEvents(r);
+      const feeBuckets = feesAddedToBucketEvents(r).filter(e => e.isCompliant == isCompliant);
 
       // all the payed rewards were added to a bucket
       const totalAdded = feeBuckets.reduce((t, l) => t.add(new BN(l.added)), new BN(0));
@@ -103,9 +103,6 @@ describe('fees-contract', async () => {
       }
       const n = bn(compliant ? compliantMembers.length : committee.length);
       const rewardsArr = committee.map(v => (!compliant || compliantMembers.includes(v)) ? fromTokenUnits(toTokenUnits(rewards.div(n))) : bn(0));
-      const remainder = rewards.sub(bnSum(rewardsArr));
-      const remainderWinnerIdx = endTime % committee.length;
-      rewardsArr[remainderWinnerIdx] = rewardsArr[remainderWinnerIdx].add(remainder);
       return rewardsArr.map(x => toTokenUnits(x));
     };
 

--- a/test/fees.spec.ts
+++ b/test/fees.spec.ts
@@ -25,7 +25,7 @@ async function sleep(ms): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe.only('fees-contract', async () => {
+describe('fees-contract', async () => {
 
   it('should distribute fees to validators in general and compliance committees', async () => {
     const d = await Driver.new({maxCommitteeSize: 4});

--- a/test/fees.spec.ts
+++ b/test/fees.spec.ts
@@ -25,7 +25,7 @@ async function sleep(ms): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe('fees-contract', async () => {
+describe.only('fees-contract', async () => {
 
   it('should distribute fees to validators in general and compliance committees', async () => {
     const d = await Driver.new({maxCommitteeSize: 4});

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -182,10 +182,10 @@ module.exports = function(chai) {
   chai.Assertion.overwriteMethod("paymentEvent", containEvent(paymentEvents));
   chai.Assertion.overwriteMethod("feeAddedToBucketEvent", containEvent(feesAddedToBucketEvents));
   chai.Assertion.overwriteMethod("bootstrapAddedToPoolEvent", containEvent(bootstrapAddedToPoolEvents));
-  chai.Assertion.overwriteMethod("bootstrapRewardsAssignedEvent", containEvent(bootstrapRewardsAssignedEvents, true, 'assignees'));
+  chai.Assertion.overwriteMethod("bootstrapRewardsAssignedEvent", containEvent(bootstrapRewardsAssignedEvents));
   chai.Assertion.overwriteMethod("stakingRewardsAssignedEvent", containEvent(stakingRewardsAssignedEvents, true, 'assignees'));
   chai.Assertion.overwriteMethod("stakingRewardsDistributedEvent", containEvent(stakingRewardsDistributed));
-  chai.Assertion.overwriteMethod("feesAssignedEvent", containEvent(feesAssignedEvents, true, 'assignees'));
+  chai.Assertion.overwriteMethod("feesAssignedEvent", containEvent(feesAssignedEvents));
   chai.Assertion.overwriteMethod("feesAddedToBucketEvent", containEvent(feesAddedToBucketEvents));
   chai.Assertion.overwriteMethod("voteOutEvent", containEvent(voteOutEvents));
   chai.Assertion.overwriteMethod("votedOutOfCommitteeEvent", containEvent(votedOutOfCommitteeEvents));

--- a/test/staking-rewards.spec.ts
+++ b/test/staking-rewards.spec.ts
@@ -188,9 +188,11 @@ describe('staking-rewards-level-flows', async () => {
       const totalCommitteeStake = bnSum(validators.map(v => v.stake));
       const actualAnnualRate = BN.min(annualRate, annualCap.mul(bn(100000)).div(totalCommitteeStake));
       const rewardsArr = validators
-          .map(v => actualAnnualRate.mul(v.stake).div(bn(100000)))
-          .map(r => toTokenUnits(r))
-          .map(r => r.mul(bn(elapsedTime)).div(bn(YEAR_IN_SECONDS)));
+          .map(v => actualAnnualRate
+              .mul(v.stake)
+              .mul(bn(elapsedTime))
+              .div(bn(YEAR_IN_SECONDS).mul(bn(100000)))
+          ).map(r => toTokenUnits(r));
       return rewardsArr.map(x => fromTokenUnits(x));
     };
 
@@ -203,7 +205,7 @@ describe('staking-rewards-level-flows', async () => {
 
     expect(assignRewardTxRes).to.have.a.stakingRewardsAssignedEvent({
       assignees: validators.map(v => v.v.address),
-      amounts: totalOrbsRewardsArr
+      amounts: totalOrbsRewardsArr.map(x => x.toString())
     });
 
     for (const v of validators) {

--- a/test/staking-rewards.spec.ts
+++ b/test/staking-rewards.spec.ts
@@ -85,7 +85,7 @@ describe('staking-rewards-level-flows', async () => {
 
     expect(assignRewardTxRes).to.have.a.stakingRewardsAssignedEvent({
       assignees: validators.map(v => v.v.address),
-      amounts: totalOrbsRewardsArr.map(x => toTokenUnits(x))
+      amounts: totalOrbsRewardsArr
     });
 
     const orbsBalances:BN[] = [];
@@ -203,7 +203,7 @@ describe('staking-rewards-level-flows', async () => {
 
     expect(assignRewardTxRes).to.have.a.stakingRewardsAssignedEvent({
       assignees: validators.map(v => v.v.address),
-      amounts: totalOrbsRewardsArr.map(x => toTokenUnits(x))
+      amounts: totalOrbsRewardsArr
     });
 
     for (const v of validators) {

--- a/typings/rewards-contract.d.ts
+++ b/typings/rewards-contract.d.ts
@@ -4,8 +4,8 @@ import * as BN from "bn.js";
 import {OwnedContract} from "./base-contract";
 
 export interface BootstrapRewardsAssignedEvent {
-    assignees: string[],
-    amounts: Array<string|BN>
+    generalValidatorAmount: string|BN,
+    certifiedValidatorAmount: string|BN
 }
 
 export interface BootstrapAddedToPoolEvent {
@@ -28,8 +28,8 @@ export interface FeesWithdrawnFromBucketEvent {
 }
 
 export interface FeesAssignedEvent {
-    assignees: string[],
-    orbs_amounts: Array<string|BN>
+    generalValidatorAmount: string|BN,
+    certifiedValidatorAmount: string|BN
 }
 
 export interface StakingRewardAssignedEvent {

--- a/typings/rewards-contract.d.ts
+++ b/typings/rewards-contract.d.ts
@@ -20,6 +20,13 @@ export interface FeesAddedToBucketEvent {
     isCompliant: boolean
 }
 
+export interface FeesWithdrawnFromBucketEvent {
+    bucketId: string|BN,
+    withdrawen: string|BN,
+    total: string|BN,
+    isCompliant: boolean
+}
+
 export interface FeesAssignedEvent {
     assignees: string[],
     orbs_amounts: Array<string|BN>


### PR DESCRIPTION
* FeesAssigned and BootstrapRewardAssigned events only report two amounts: certified amount and general amount. THe list of committee members can be obtained by committee events.
* The remainder from fee division is added back to the current bucket instead of assigned to a random member
* New event: FeeWIthdrawnFromBucket, complements FeeAddedToBucket
* Changed stakingRewardsAssigned amounts back to uint256 granularity