### PR TITLE
SUBSCRIPTION: Change genesis ref from block number to timestamp

### DIFF
--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -18,7 +18,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         string tier;
         uint256 rate;
         uint expiresAt;
-        uint genRef;
+        uint256 genRefTime;
         address owner;
         string deploymentSubset;
         bool isCompliant;
@@ -63,7 +63,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         uint vcid = nextVcid++;
         VirtualChain memory vc = VirtualChain({
             expiresAt: block.timestamp,
-            genRef: block.number + 300,
+            genRefTime: now + (3 hours),
             owner: owner,
             tier: tier,
             rate: rate,
@@ -75,7 +75,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         emit VcCreated(vcid, owner);
 
         _extendSubscription(vcid, amount, owner);
-        return (vcid, vc.genRef);
+        return (vcid, vc.genRefTime);
     }
 
     function extendSubscription(uint256 vcid, uint256 amount, address payer) external {
@@ -101,7 +101,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         }
         vc.expiresAt = vc.expiresAt.add(amount.mul(30 days).div(vc.rate));
 
-        emit SubscriptionChanged(vcid, vc.genRef, vc.expiresAt, vc.tier, vc.deploymentSubset);
+        emit SubscriptionChanged(vcid, vc.genRefTime, vc.expiresAt, vc.tier, vc.deploymentSubset);
         emit Payment(vcid, payer, amount, vc.tier, vc.rate);
     }
 

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -30,6 +30,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
     mapping (uint => VirtualChain) virtualChains;
 
     uint nextVcid;
+    uint genesisRefTimeDelay;
 
     IERC20 erc20;
 
@@ -37,6 +38,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         require(address(_erc20) != address(0), "erc20 must not be 0");
 
         nextVcid = 1000000;
+        genesisRefTimeDelay = 3 hours;
         erc20 = _erc20;
     }
 
@@ -63,7 +65,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         uint vcid = nextVcid++;
         VirtualChain memory vc = VirtualChain({
             expiresAt: block.timestamp,
-            genRefTime: now + (3 hours),
+            genRefTime: now + genesisRefTimeDelay,
             owner: owner,
             tier: tier,
             rate: rate,
@@ -105,4 +107,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         emit Payment(vcid, payer, amount, vc.tier, vc.rate);
     }
 
+    function setGenesisRefTimeDelay(uint256 newGenesisRefTimeDelay) external onlyFunctionalOwner {
+        genesisRefTimeDelay = newGenesisRefTimeDelay;
+    }
 }

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -110,4 +110,8 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
     function setGenesisRefTimeDelay(uint256 newGenesisRefTimeDelay) external onlyFunctionalOwner {
         genesisRefTimeDelay = newGenesisRefTimeDelay;
     }
+
+    function getGenesisRefTimeDelay() external view returns (uint) {
+        return genesisRefTimeDelay;
+    }
 }

--- a/contracts/spec_interfaces/ISubscriptions.sol
+++ b/contracts/spec_interfaces/ISubscriptions.sol
@@ -32,6 +32,9 @@ interface ISubscriptions {
     /// @dev Transfers VC ownership to a new owner (can only be called by the current owner)
     function setVcOwner(uint256 vcid, address owner) external /* onlyVcOwner */;
 
+    /// @dev Returns the genesis ref time delay
+    function getGenesisRefTimeDelay() external view returns (uint256);
+
     /*
      *   Governance methods
      */

--- a/contracts/spec_interfaces/ISubscriptions.sol
+++ b/contracts/spec_interfaces/ISubscriptions.sol
@@ -4,7 +4,7 @@ import "./IContractRegistry.sol";
 
 /// @title Subscriptions contract interface
 interface ISubscriptions {
-    event SubscriptionChanged(uint256 vcid, uint256 genRef, uint256 expiresAt, string tier, string deploymentSubset);
+    event SubscriptionChanged(uint256 vcid, uint256 genRefTime, uint256 expiresAt, string tier, string deploymentSubset);
     event Payment(uint256 vcid, address by, uint256 amount, string tier, uint256 rate);
     event VcConfigRecordChanged(uint256 vcid, string key, string value);
     event SubscriberAdded(address subscriber);

--- a/contracts/spec_interfaces/ISubscriptions.sol
+++ b/contracts/spec_interfaces/ISubscriptions.sol
@@ -39,6 +39,9 @@ interface ISubscriptions {
     /// @dev Called by the owner to authorize a subscriber (plan)
     function addSubscriber(address addr) external /* onlyFunctionalOwner */;
 
+    /// @dev Called by the owner to set the genesis ref time delay
+    function setGenesisRefTimeDelay(uint256 newGenesisRefTimeDelay) external /* onlyFunctionalOwner */;
+
     /// @dev Updates the address of the contract registry
     function setContractRegistry(IContractRegistry _contractRegistry) external /* onlyMigrationOwner */;
 

--- a/test/driver.ts
+++ b/test/driver.ts
@@ -23,6 +23,7 @@ import {OwnedContract} from "../typings/base-contract";
 export const BANNING_LOCK_TIMEOUT = 7*24*60*60;
 export const DEPLOYMENT_SUBSET_MAIN = "main";
 export const DEPLOYMENT_SUBSET_CANARY = "canary";
+export const DEFAULT_GENESIS_REF_TIME_DELAY = 3*60*60;
 
 export type DriverOptions = {
     maxCommitteeSize: number;

--- a/test/driver.ts
+++ b/test/driver.ts
@@ -23,7 +23,6 @@ import {OwnedContract} from "../typings/base-contract";
 export const BANNING_LOCK_TIMEOUT = 7*24*60*60;
 export const DEPLOYMENT_SUBSET_MAIN = "main";
 export const DEPLOYMENT_SUBSET_CANARY = "canary";
-export const DEFAULT_GENESIS_REF_TIME_DELAY = 3*60*60;
 
 export type DriverOptions = {
     maxCommitteeSize: number;

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -3,6 +3,7 @@ import BN from "bn.js";
 import * as _ from "lodash";
 import { Web3Driver } from "../eth";
 import {Driver} from "./driver";
+import {TransactionReceipt} from "web3-core";
 
 export const retry = (n: number, f: () => Promise<void>) => async  () => {
     for (let i = 0; i < n; i++) {
@@ -56,6 +57,10 @@ export async function getTopBlockTimestamp(d: Driver) : Promise<number> {
                     err ? reject(err): resolve(block.timestamp)
             )
     );
+}
+
+export async function txTimestamp(web3: Web3Driver, r: TransactionReceipt): Promise<number> { // TODO move
+    return (await web3.eth.getBlock(r.blockNumber)).timestamp as number;
 }
 
 export function fromTokenUnits(n: (number|BN)): BN {

--- a/test/staking-rewards.spec.ts
+++ b/test/staking-rewards.spec.ts
@@ -4,7 +4,7 @@ import * as _ from "lodash";
 import BN from "bn.js";
 import {Driver, DEPLOYMENT_SUBSET_MAIN, expectRejected} from "./driver";
 import chai from "chai";
-import {bn, bnSum, evmIncreaseTime, fromTokenUnits, toTokenUnits} from "./helpers";
+import {bn, bnSum, evmIncreaseTime, fromTokenUnits, toTokenUnits, txTimestamp} from "./helpers";
 import {TransactionReceipt} from "web3-core";
 import {Web3Driver} from "../eth";
 
@@ -12,10 +12,6 @@ chai.use(require('chai-bn')(BN));
 chai.use(require('./matchers'));
 
 const YEAR_IN_SECONDS = 365*24*60*60;
-
-async function txTimestamp(web3: Web3Driver, r: TransactionReceipt): Promise<number> { // TODO move
-  return (await web3.eth.getBlock(r.blockNumber)).timestamp as number;
-}
 
 const expect = chai.expect;
 

--- a/test/subscriptions.spec.ts
+++ b/test/subscriptions.spec.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 
 import BN from "bn.js";
-import {DEFAULT_GENESIS_REF_TIME_DELAY, Driver, expectRejected, ZERO_ADDR} from "./driver";
+import {Driver, expectRejected, ZERO_ADDR} from "./driver";
 import chai from "chai";
 import {subscriptionChangedEvents} from "./event-parsing";
 import {bn, txTimestamp} from "./helpers";
@@ -29,9 +29,10 @@ describe('subscriptions-high-level-flows', async () => {
     expect(r).to.have.subscriptionChangedEvent();
     const firstSubsc = subscriptionChangedEvents(r).pop()!;
 
+    const genesisRefTimeDelay = await d.subscriptions.getGenesisRefTimeDelay();
     const blockNumber = new BN(r.blockNumber);
     const blockTimestamp = new BN((await d.web3.eth.getBlock(blockNumber)).timestamp);
-    const expectedGenRefTime = blockTimestamp.add(bn(DEFAULT_GENESIS_REF_TIME_DELAY));
+    const expectedGenRefTime = blockTimestamp.add(bn(genesisRefTimeDelay));
     const secondsInMonth = new BN(30 * 24 * 60 * 60);
     const payedDurationInSeconds = firstPayment.mul(secondsInMonth).div(monthlyRate);
     let expectedExpiration = new BN(blockTimestamp).add(payedDurationInSeconds);

--- a/test/subscriptions.spec.ts
+++ b/test/subscriptions.spec.ts
@@ -31,13 +31,13 @@ describe('subscriptions-high-level-flows', async () => {
 
     const blockNumber = new BN(r.blockNumber);
     const blockTimestamp = new BN((await d.web3.eth.getBlock(blockNumber)).timestamp);
-    const expectedGenRef = blockNumber.add(new BN('300'));
+    const expectedGenRefTime = blockTimestamp.add(bn(3*60*60));
     const secondsInMonth = new BN(30 * 24 * 60 * 60);
     const payedDurationInSeconds = firstPayment.mul(secondsInMonth).div(monthlyRate);
     let expectedExpiration = new BN(blockTimestamp).add(payedDurationInSeconds);
 
     expect(firstSubsc.vcid).to.exist;
-    expect(firstSubsc.genRef).to.be.bignumber.equal(expectedGenRef);
+    expect(firstSubsc.genRefTime).to.be.bignumber.equal(expectedGenRefTime);
     expect(firstSubsc.expiresAt).to.be.bignumber.equal(expectedExpiration);
     expect(firstSubsc.tier).to.equal("defaultTier");
 
@@ -60,7 +60,7 @@ describe('subscriptions-high-level-flows', async () => {
     expectedExpiration = new BN(firstSubsc.expiresAt).add(extendedDurationInSeconds);
 
     expect(secondSubsc.vcid).to.equal(firstSubsc.vcid);
-    expect(secondSubsc.genRef).to.be.equal(firstSubsc.genRef);
+    expect(secondSubsc.genRefTime).to.be.equal(firstSubsc.genRefTime);
     expect(secondSubsc.expiresAt).to.be.bignumber.equal(expectedExpiration);
     expect(secondSubsc.tier).to.equal("defaultTier");
 
@@ -92,13 +92,13 @@ describe('subscriptions-high-level-flows', async () => {
 
     const blockNumber = new BN(r.blockNumber);
     const blockTimestamp = new BN((await d.web3.eth.getBlock(blockNumber)).timestamp);
-    const expectedGenRef = blockNumber.add(new BN('300'));
+    const expectedGenRef = blockTimestamp.add(bn(3*60*60));
     const secondsInMonth = new BN(30 * 24 * 60 * 60);
     const payedDurationInSeconds = firstPayment.mul(secondsInMonth).div(monthlyRate);
     let expectedExpiration = new BN(blockTimestamp).add(payedDurationInSeconds);
 
     expect(firstSubsc.vcid).to.exist;
-    expect(firstSubsc.genRef).to.be.bignumber.equal(expectedGenRef);
+    expect(firstSubsc.genRefTime).to.be.bignumber.equal(expectedGenRef);
     expect(firstSubsc.expiresAt).to.be.bignumber.equal(expectedExpiration);
     expect(firstSubsc.tier).to.equal("defaultTier");
 
@@ -121,7 +121,7 @@ describe('subscriptions-high-level-flows', async () => {
     expectedExpiration = new BN(firstSubsc.expiresAt).add(extendedDurationInSeconds);
 
     expect(secondSubsc.vcid).to.equal(firstSubsc.vcid);
-    expect(secondSubsc.genRef).to.be.equal(firstSubsc.genRef);
+    expect(secondSubsc.genRefTime).to.be.equal(firstSubsc.genRefTime);
     expect(secondSubsc.expiresAt).to.be.bignumber.equal(expectedExpiration);
     expect(secondSubsc.tier).to.equal("defaultTier");
 

--- a/test/subscriptions.spec.ts
+++ b/test/subscriptions.spec.ts
@@ -1,10 +1,10 @@
 import 'mocha';
 
 import BN from "bn.js";
-import {Driver, expectRejected, ZERO_ADDR} from "./driver";
+import {DEFAULT_GENESIS_REF_TIME_DELAY, Driver, expectRejected, ZERO_ADDR} from "./driver";
 import chai from "chai";
 import {subscriptionChangedEvents} from "./event-parsing";
-import {bn} from "./helpers";
+import {bn, txTimestamp} from "./helpers";
 chai.use(require('chai-bn')(BN));
 chai.use(require('./matchers'));
 
@@ -31,7 +31,7 @@ describe('subscriptions-high-level-flows', async () => {
 
     const blockNumber = new BN(r.blockNumber);
     const blockTimestamp = new BN((await d.web3.eth.getBlock(blockNumber)).timestamp);
-    const expectedGenRefTime = blockTimestamp.add(bn(3*60*60));
+    const expectedGenRefTime = blockTimestamp.add(bn(DEFAULT_GENESIS_REF_TIME_DELAY));
     const secondsInMonth = new BN(30 * 24 * 60 * 60);
     const payedDurationInSeconds = firstPayment.mul(secondsInMonth).div(monthlyRate);
     let expectedExpiration = new BN(blockTimestamp).add(payedDurationInSeconds);
@@ -258,5 +258,24 @@ describe('subscriptions-high-level-flows', async () => {
     });
 
   });
+
+  it('allows only the functional owner to set default genesis ref time delay', async () => {
+    const d = await Driver.new();
+
+    const newDelay = 4*60*60;
+    await expectRejected(d.subscriptions.setGenesisRefTimeDelay(newDelay, {from: d.migrationOwner.address}));
+    await d.subscriptions.setGenesisRefTimeDelay(newDelay, {from: d.functionalOwner.address});
+
+    const subs = await d.newSubscriber("tier", 1);
+
+    const owner = d.newParticipant();
+
+    const amount = 10;
+    await owner.assignAndApproveOrbs(amount, subs.address);
+    let r = await subs.createVC(amount, false, "main", {from: owner.address});
+    expect(r).to.have.a.subscriptionChangedEvent({
+      genRefTime: bn(await txTimestamp(d.web3, r) + newDelay)
+    });
+  })
 
 });

--- a/typings/subscriptions-contract.d.ts
+++ b/typings/subscriptions-contract.d.ts
@@ -45,4 +45,5 @@ export interface SubscriptionsContract extends OwnedContract {
   setContractRegistry(contractRegistry: string, params?: TransactionConfig): Promise<TransactionReceipt>;
   setVcOwner(vcid: number|BN, owner: string, params?: TransactionConfig): Promise<TransactionReceipt>;
   setGenesisRefTimeDelay(genRefTimeDelay: number|BN, params?: TransactionConfig): Promise<TransactionReceipt>;
+  getGenesisRefTimeDelay(params?: TransactionConfig): Promise<string>;
 }

--- a/typings/subscriptions-contract.d.ts
+++ b/typings/subscriptions-contract.d.ts
@@ -7,7 +7,7 @@ import {OwnedContract} from "./base-contract";
 
 export interface SubscriptionChangedEvent {
   vcid: number | BN;
-  genRef: number | BN;
+  genRefTime: number | BN;
   expiresAt: number | BN;
   tier: 'defaultTier';
   deploymentSubset: typeof DEPLOYMENT_SUBSET_MAIN | typeof DEPLOYMENT_SUBSET_CANARY;

--- a/typings/subscriptions-contract.d.ts
+++ b/typings/subscriptions-contract.d.ts
@@ -44,4 +44,5 @@ export interface SubscriptionsContract extends OwnedContract {
   getVcConfigRecord(vcid: number|BN, key: string, params?: TransactionConfig): Promise<TransactionReceipt>;
   setContractRegistry(contractRegistry: string, params?: TransactionConfig): Promise<TransactionReceipt>;
   setVcOwner(vcid: number|BN, owner: string, params?: TransactionConfig): Promise<TransactionReceipt>;
+  setGenesisRefTimeDelay(genRefTimeDelay: number|BN, params?: TransactionConfig): Promise<TransactionReceipt>;
 }


### PR DESCRIPTION
The genesis ref of a new VC is set to a configurable delay from the current time (default 3 hours) as opposed to 300 blocks from the current block.