### PR TITLE
Contracts Lockdown

### DIFF
--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -79,7 +79,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 	/// @dev Called by: Elections contract
 	/// Notifies a weight change for sorting to a relevant committee member.
 	/// weight = 0 indicates removal of the member from the committee (for example on unregister, voteUnready, voteOut)
-	function memberWeightChange(address addr, uint256 weight) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function memberWeightChange(address addr, uint256 weight) external onlyElectionsContract onlyWhenActive returns (bool committeeChanged, bool standbysChanged) {
 		require(uint256(uint128(weight)) == weight, "weight is out of range");
 
 		MemberData memory memberData = membersData[addr];
@@ -93,7 +93,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function memberReadyToSync(address addr, bool readyForCommittee) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function memberReadyToSync(address addr, bool readyForCommittee) external onlyElectionsContract onlyWhenActive returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -107,7 +107,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function memberNotReadyToSync(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function memberNotReadyToSync(address addr) external onlyElectionsContract onlyWhenActive returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -121,7 +121,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function memberComplianceChange(address addr, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool commiteeChanged, bool standbysChanged) {
+	function memberComplianceChange(address addr, bool isCompliant) external onlyElectionsContract onlyWhenActive returns (bool commiteeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -134,7 +134,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function addMember(address addr, uint256 weight, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function addMember(address addr, uint256 weight, bool isCompliant) external onlyElectionsContract onlyWhenActive returns (bool committeeChanged, bool standbysChanged) {
 		require(uint256(uint128(weight)) == weight, "weight is out of range");
 
 		if (membersData[addr].isMember) {
@@ -157,7 +157,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 
 	/// @dev Called by: Elections contract
 	/// Notifies a a member removal for example due to voteOut / voteUnready
-	function removeMember(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function removeMember(address addr) external onlyElectionsContract onlyWhenActive returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		memberData.isMember = false;
 		(committeeChanged, standbysChanged) = _rankAndUpdateMember(Member({

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -79,7 +79,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 	/// @dev Called by: Elections contract
 	/// Notifies a weight change for sorting to a relevant committee member.
 	/// weight = 0 indicates removal of the member from the committee (for example on unregister, voteUnready, voteOut)
-	function memberWeightChange(address addr, uint256 weight) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function onlyWhenActive(address addr, uint256 weight) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		require(uint256(uint128(weight)) == weight, "weight is out of range");
 
 		MemberData memory memberData = membersData[addr];
@@ -93,7 +93,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function memberReadyToSync(address addr, bool readyForCommittee) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function onlyWhenActive(address addr, bool readyForCommittee) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -107,7 +107,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function memberNotReadyToSync(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function onlyWhenActive(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -121,7 +121,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function memberComplianceChange(address addr, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool commiteeChanged, bool standbysChanged) {
+	function onlyWhenActive(address addr, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool commiteeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -134,7 +134,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function addMember(address addr, uint256 weight, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function onlyWhenActive(address addr, uint256 weight, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		require(uint256(uint128(weight)) == weight, "weight is out of range");
 
 		if (membersData[addr].isMember) {
@@ -157,7 +157,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 
 	/// @dev Called by: Elections contract
 	/// Notifies a a member removal for example due to voteOut / voteUnready
-	function removeMember(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function onlyWhenActive(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		memberData.isMember = false;
 		(committeeChanged, standbysChanged) = _rankAndUpdateMember(Member({

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -7,7 +7,7 @@ import "./ContractRegistryAccessor.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 
 /// @title Elections contract interface
-contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctionalOwnership {
+contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
 	address[] participantAddresses;
 
 	struct MemberData { // TODO can be reduced to 1 state entry

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -79,7 +79,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 	/// @dev Called by: Elections contract
 	/// Notifies a weight change for sorting to a relevant committee member.
 	/// weight = 0 indicates removal of the member from the committee (for example on unregister, voteUnready, voteOut)
-	function onlyWhenActive(address addr, uint256 weight) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function memberWeightChange(address addr, uint256 weight) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		require(uint256(uint128(weight)) == weight, "weight is out of range");
 
 		MemberData memory memberData = membersData[addr];
@@ -93,7 +93,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function onlyWhenActive(address addr, bool readyForCommittee) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function memberReadyToSync(address addr, bool readyForCommittee) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -107,7 +107,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function onlyWhenActive(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function memberNotReadyToSync(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -121,7 +121,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function onlyWhenActive(address addr, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool commiteeChanged, bool standbysChanged) {
+	function memberComplianceChange(address addr, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool commiteeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -134,7 +134,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function onlyWhenActive(address addr, uint256 weight, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function addMember(address addr, uint256 weight, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		require(uint256(uint128(weight)) == weight, "weight is out of range");
 
 		if (membersData[addr].isMember) {
@@ -157,7 +157,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 
 	/// @dev Called by: Elections contract
 	/// Notifies a a member removal for example due to voteOut / voteUnready
-	function onlyWhenActive(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
+	function removeMember(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		memberData.isMember = false;
 		(committeeChanged, standbysChanged) = _rankAndUpdateMember(Member({

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -79,7 +79,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 	/// @dev Called by: Elections contract
 	/// Notifies a weight change for sorting to a relevant committee member.
 	/// weight = 0 indicates removal of the member from the committee (for example on unregister, voteUnready, voteOut)
-	function memberWeightChange(address addr, uint256 weight) external onlyElectionsContract returns (bool committeeChanged, bool standbysChanged) {
+	function memberWeightChange(address addr, uint256 weight) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		require(uint256(uint128(weight)) == weight, "weight is out of range");
 
 		MemberData memory memberData = membersData[addr];
@@ -93,7 +93,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function memberReadyToSync(address addr, bool readyForCommittee) external onlyElectionsContract returns (bool committeeChanged, bool standbysChanged) {
+	function memberReadyToSync(address addr, bool readyForCommittee) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -107,7 +107,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function memberNotReadyToSync(address addr) external onlyElectionsContract returns (bool committeeChanged, bool standbysChanged) {
+	function memberNotReadyToSync(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -121,7 +121,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function memberComplianceChange(address addr, bool isCompliant) external onlyElectionsContract returns (bool commiteeChanged, bool standbysChanged) {
+	function memberComplianceChange(address addr, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool commiteeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		if (!memberData.isMember) {
 			return (false, false);
@@ -134,7 +134,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 		}));
 	}
 
-	function addMember(address addr, uint256 weight, bool isCompliant) external onlyElectionsContract returns (bool committeeChanged, bool standbysChanged) {
+	function addMember(address addr, uint256 weight, bool isCompliant) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		require(uint256(uint128(weight)) == weight, "weight is out of range");
 
 		if (membersData[addr].isMember) {
@@ -157,7 +157,7 @@ contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctio
 
 	/// @dev Called by: Elections contract
 	/// Notifies a a member removal for example due to voteOut / voteUnready
-	function removeMember(address addr) external onlyElectionsContract returns (bool committeeChanged, bool standbysChanged) {
+	function removeMember(address addr) external onlyElectionsContract onlyWhenUnlocked returns (bool committeeChanged, bool standbysChanged) {
 		MemberData memory memberData = membersData[addr];
 		memberData.isMember = false;
 		(committeeChanged, standbysChanged) = _rankAndUpdateMember(Member({

--- a/contracts/Compliance.sol
+++ b/contracts/Compliance.sol
@@ -16,7 +16,7 @@ contract Compliance is ICompliance, ContractRegistryAccessor, WithClaimableFunct
         return validatorCompliance[addr];
     }
 
-    function onlyWhenActive(address addr, bool isCompliant) external onlyFunctionalOwner onlyWhenUnlocked {
+    function setValidatorCompliance(address addr, bool isCompliant) external onlyFunctionalOwner onlyWhenUnlocked {
         validatorCompliance[addr] = isCompliant;
         emit ValidatorComplianceUpdate(addr, isCompliant);
         getElectionsContract().validatorComplianceChanged(addr, isCompliant);

--- a/contracts/Compliance.sol
+++ b/contracts/Compliance.sol
@@ -16,7 +16,7 @@ contract Compliance is ICompliance, ContractRegistryAccessor, WithClaimableFunct
         return validatorCompliance[addr];
     }
 
-    function setValidatorCompliance(address addr, bool isCompliant) external onlyFunctionalOwner onlyWhenUnlocked {
+    function onlyWhenActive(address addr, bool isCompliant) external onlyFunctionalOwner onlyWhenUnlocked {
         validatorCompliance[addr] = isCompliant;
         emit ValidatorComplianceUpdate(addr, isCompliant);
         getElectionsContract().validatorComplianceChanged(addr, isCompliant);

--- a/contracts/Compliance.sol
+++ b/contracts/Compliance.sol
@@ -16,7 +16,7 @@ contract Compliance is ICompliance, ContractRegistryAccessor, WithClaimableFunct
         return validatorCompliance[addr];
     }
 
-    function setValidatorCompliance(address addr, bool isCompliant) external onlyFunctionalOwner {
+    function setValidatorCompliance(address addr, bool isCompliant) external onlyFunctionalOwner onlyWhenUnlocked {
         validatorCompliance[addr] = isCompliant;
         emit ValidatorComplianceUpdate(addr, isCompliant);
         getElectionsContract().validatorComplianceChanged(addr, isCompliant);

--- a/contracts/Compliance.sol
+++ b/contracts/Compliance.sol
@@ -16,7 +16,7 @@ contract Compliance is ICompliance, ContractRegistryAccessor, WithClaimableFunct
         return validatorCompliance[addr];
     }
 
-    function setValidatorCompliance(address addr, bool isCompliant) external onlyFunctionalOwner onlyWhenUnlocked {
+    function setValidatorCompliance(address addr, bool isCompliant) external onlyFunctionalOwner onlyWhenActive {
         validatorCompliance[addr] = isCompliant;
         emit ValidatorComplianceUpdate(addr, isCompliant);
         getElectionsContract().validatorComplianceChanged(addr, isCompliant);

--- a/contracts/Compliance.sol
+++ b/contracts/Compliance.sol
@@ -4,7 +4,7 @@ import "./spec_interfaces/ICompliance.sol";
 import "./ContractRegistryAccessor.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 
-contract Compliance is ICompliance, ContractRegistryAccessor, WithClaimableFunctionalOwnership {
+contract Compliance is ICompliance, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
 
     mapping (address => bool) validatorCompliance;
 

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -10,12 +10,13 @@ import "./spec_interfaces/ISubscriptions.sol";
 import "./spec_interfaces/IDelegation.sol";
 import "./interfaces/IRewards.sol";
 import "./WithClaimableMigrationOwnership.sol";
+import "./Lockable.sol";
 
-contract ContractRegistryAccessor is WithClaimableMigrationOwnership {
+contract ContractRegistryAccessor is Lockable {
 
     IContractRegistry contractRegistry;
 
-    function setContractRegistry(IContractRegistry _contractRegistry) external onlyMigrationOwner {
+    function setContractRegistry(IContractRegistry _contractRegistry) external onlyMigrationOwner onlyWhenUnlocked {
         require(address(_contractRegistry) != address(0), "contractRegistry must not be 0");
         contractRegistry = _contractRegistry;
     }

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -12,11 +12,11 @@ import "./interfaces/IRewards.sol";
 import "./WithClaimableMigrationOwnership.sol";
 import "./Lockable.sol";
 
-contract ContractRegistryAccessor is Lockable {
+contract ContractRegistryAccessor {
 
     IContractRegistry contractRegistry;
 
-    function setContractRegistry(IContractRegistry _contractRegistry) external onlyMigrationOwner onlyWhenActive {
+    function setContractRegistry(IContractRegistry _contractRegistry) external onlyMigrationOwner {
         require(address(_contractRegistry) != address(0), "contractRegistry must not be 0");
         contractRegistry = _contractRegistry;
     }
@@ -56,6 +56,5 @@ contract ContractRegistryAccessor is Lockable {
     function getSubscriptionsContract() public view returns (ISubscriptions) {
         return ISubscriptions(contractRegistry.get("subscriptions"));
     }
-
 
 }

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -16,7 +16,7 @@ contract ContractRegistryAccessor is Lockable {
 
     IContractRegistry contractRegistry;
 
-    function setContractRegistry(IContractRegistry _contractRegistry) external onlyMigrationOwner onlyWhenUnlocked {
+    function setContractRegistry(IContractRegistry _contractRegistry) external onlyMigrationOwner onlyWhenActive {
         require(address(_contractRegistry) != address(0), "contractRegistry must not be 0");
         contractRegistry = _contractRegistry;
     }

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -12,7 +12,7 @@ import "./interfaces/IRewards.sol";
 import "./WithClaimableMigrationOwnership.sol";
 import "./Lockable.sol";
 
-contract ContractRegistryAccessor {
+contract ContractRegistryAccessor is WithClaimableMigrationOwnership {
 
     IContractRegistry contractRegistry;
 

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -16,7 +16,7 @@ contract ContractRegistryAccessor is Lockable {
 
     IContractRegistry contractRegistry;
 
-    function onlyWhenActive(IContractRegistry _contractRegistry) external onlyMigrationOwner onlyWhenUnlocked {
+    function setContractRegistry(IContractRegistry _contractRegistry) external onlyMigrationOwner onlyWhenUnlocked {
         require(address(_contractRegistry) != address(0), "contractRegistry must not be 0");
         contractRegistry = _contractRegistry;
     }

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -16,7 +16,7 @@ contract ContractRegistryAccessor is Lockable {
 
     IContractRegistry contractRegistry;
 
-    function setContractRegistry(IContractRegistry _contractRegistry) external onlyMigrationOwner onlyWhenUnlocked {
+    function onlyWhenActive(IContractRegistry _contractRegistry) external onlyMigrationOwner onlyWhenUnlocked {
         require(address(_contractRegistry) != address(0), "contractRegistry must not be 0");
         contractRegistry = _contractRegistry;
     }

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -30,7 +30,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 	constructor() public {
 	}
 
-	function delegate(address to) external {
+	function delegate(address to) external onlyWhenUnlocked {
 		address prevDelegate = getDelegation(msg.sender);
 
 		require(to != address(0), "cannot delegate to a zero address");
@@ -73,7 +73,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 		}
 	}
 
-	function stakeChange(address _stakeOwner, uint256 _amount, bool _sign, uint256 _updatedStake) external onlyStakingContract {
+	function stakeChange(address _stakeOwner, uint256 _amount, bool _sign, uint256 _updatedStake) external onlyStakingContract onlyWhenUnlocked {
 		_stakeChange(_stakeOwner, _amount, _sign);
 		emitDelegatedStakeChanged(getDelegation(_stakeOwner), _stakeOwner, _updatedStake);
 	}
@@ -113,7 +113,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 	}
 
 	// TODO add tests to equivalence of batched and non batched notifications
-	function stakeChangeBatch(address[] calldata _stakeOwners, uint256[] calldata _amounts, bool[] calldata _signs, uint256[] calldata _updatedStakes) external onlyStakingContract {
+	function stakeChangeBatch(address[] calldata _stakeOwners, uint256[] calldata _amounts, bool[] calldata _signs, uint256[] calldata _updatedStakes) external onlyStakingContract onlyWhenUnlocked {
 		uint batchLength = _stakeOwners.length;
 		require(batchLength == _amounts.length, "_stakeOwners, _amounts - array length mismatch");
 		require(batchLength == _signs.length, "_stakeOwners, _signs - array length mismatch");
@@ -133,7 +133,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 		return (d == address(0)) ? addr : d;
 	}
 
-	function stakeMigration(address _stakeOwner, uint256 _amount) external onlyStakingContract {}
+	function stakeMigration(address _stakeOwner, uint256 _amount) external onlyStakingContract onlyWhenUnlocked {}
 
 	struct ProcessSequencesParams {
 		address[] stakeOwners;

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -13,7 +13,7 @@ import "./ContractRegistryAccessor.sol";
 import "./spec_interfaces/IDelegation.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 
-contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAccessor, WithClaimableFunctionalOwnership {
+contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
 	using SafeMath for uint256;
 
 	// TODO consider using structs instead of multiple mappings

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -30,7 +30,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 	constructor() public {
 	}
 
-	function onlyWhenActive(address to) external onlyWhenUnlocked {
+	function delegate(address to) external onlyWhenUnlocked {
 		address prevDelegate = getDelegation(msg.sender);
 
 		require(to != address(0), "cannot delegate to a zero address");
@@ -73,7 +73,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 		}
 	}
 
-	function onlyWhenActive(address _stakeOwner, uint256 _amount, bool _sign, uint256 _updatedStake) external onlyStakingContract onlyWhenUnlocked {
+	function stakeChange(address _stakeOwner, uint256 _amount, bool _sign, uint256 _updatedStake) external onlyStakingContract onlyWhenUnlocked {
 		_stakeChange(_stakeOwner, _amount, _sign);
 		emitDelegatedStakeChanged(getDelegation(_stakeOwner), _stakeOwner, _updatedStake);
 	}
@@ -113,7 +113,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 	}
 
 	// TODO add tests to equivalence of batched and non batched notifications
-	function onlyWhenActive(address[] calldata _stakeOwners, uint256[] calldata _amounts, bool[] calldata _signs, uint256[] calldata _updatedStakes) external onlyStakingContract onlyWhenUnlocked {
+	function stakeChangeBatch(address[] calldata _stakeOwners, uint256[] calldata _amounts, bool[] calldata _signs, uint256[] calldata _updatedStakes) external onlyStakingContract onlyWhenUnlocked {
 		uint batchLength = _stakeOwners.length;
 		require(batchLength == _amounts.length, "_stakeOwners, _amounts - array length mismatch");
 		require(batchLength == _signs.length, "_stakeOwners, _signs - array length mismatch");
@@ -133,7 +133,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 		return (d == address(0)) ? addr : d;
 	}
 
-	function onlyWhenActive(address _stakeOwner, uint256 _amount) external onlyStakingContract onlyWhenUnlocked {}
+	function stakeMigration(address _stakeOwner, uint256 _amount) external onlyStakingContract onlyWhenUnlocked {}
 
 	struct ProcessSequencesParams {
 		address[] stakeOwners;

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -30,7 +30,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 	constructor() public {
 	}
 
-	function delegate(address to) external onlyWhenUnlocked {
+	function delegate(address to) external onlyWhenActive {
 		address prevDelegate = getDelegation(msg.sender);
 
 		require(to != address(0), "cannot delegate to a zero address");
@@ -73,7 +73,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 		}
 	}
 
-	function stakeChange(address _stakeOwner, uint256 _amount, bool _sign, uint256 _updatedStake) external onlyStakingContract onlyWhenUnlocked {
+	function stakeChange(address _stakeOwner, uint256 _amount, bool _sign, uint256 _updatedStake) external onlyStakingContract onlyWhenActive {
 		_stakeChange(_stakeOwner, _amount, _sign);
 		emitDelegatedStakeChanged(getDelegation(_stakeOwner), _stakeOwner, _updatedStake);
 	}
@@ -113,7 +113,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 	}
 
 	// TODO add tests to equivalence of batched and non batched notifications
-	function stakeChangeBatch(address[] calldata _stakeOwners, uint256[] calldata _amounts, bool[] calldata _signs, uint256[] calldata _updatedStakes) external onlyStakingContract onlyWhenUnlocked {
+	function stakeChangeBatch(address[] calldata _stakeOwners, uint256[] calldata _amounts, bool[] calldata _signs, uint256[] calldata _updatedStakes) external onlyStakingContract onlyWhenActive {
 		uint batchLength = _stakeOwners.length;
 		require(batchLength == _amounts.length, "_stakeOwners, _amounts - array length mismatch");
 		require(batchLength == _signs.length, "_stakeOwners, _signs - array length mismatch");
@@ -133,7 +133,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 		return (d == address(0)) ? addr : d;
 	}
 
-	function stakeMigration(address _stakeOwner, uint256 _amount) external onlyStakingContract onlyWhenUnlocked {}
+	function stakeMigration(address _stakeOwner, uint256 _amount) external onlyStakingContract onlyWhenActive {}
 
 	struct ProcessSequencesParams {
 		address[] stakeOwners;

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -30,7 +30,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 	constructor() public {
 	}
 
-	function delegate(address to) external onlyWhenUnlocked {
+	function onlyWhenActive(address to) external onlyWhenUnlocked {
 		address prevDelegate = getDelegation(msg.sender);
 
 		require(to != address(0), "cannot delegate to a zero address");
@@ -73,7 +73,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 		}
 	}
 
-	function stakeChange(address _stakeOwner, uint256 _amount, bool _sign, uint256 _updatedStake) external onlyStakingContract onlyWhenUnlocked {
+	function onlyWhenActive(address _stakeOwner, uint256 _amount, bool _sign, uint256 _updatedStake) external onlyStakingContract onlyWhenUnlocked {
 		_stakeChange(_stakeOwner, _amount, _sign);
 		emitDelegatedStakeChanged(getDelegation(_stakeOwner), _stakeOwner, _updatedStake);
 	}
@@ -113,7 +113,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 	}
 
 	// TODO add tests to equivalence of batched and non batched notifications
-	function stakeChangeBatch(address[] calldata _stakeOwners, uint256[] calldata _amounts, bool[] calldata _signs, uint256[] calldata _updatedStakes) external onlyStakingContract onlyWhenUnlocked {
+	function onlyWhenActive(address[] calldata _stakeOwners, uint256[] calldata _amounts, bool[] calldata _signs, uint256[] calldata _updatedStakes) external onlyStakingContract onlyWhenUnlocked {
 		uint batchLength = _stakeOwners.length;
 		require(batchLength == _amounts.length, "_stakeOwners, _amounts - array length mismatch");
 		require(batchLength == _signs.length, "_stakeOwners, _signs - array length mismatch");
@@ -133,7 +133,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAcce
 		return (d == address(0)) ? addr : d;
 	}
 
-	function stakeMigration(address _stakeOwner, uint256 _amount) external onlyStakingContract onlyWhenUnlocked {}
+	function onlyWhenActive(address _stakeOwner, uint256 _amount) external onlyStakingContract onlyWhenUnlocked {}
 
 	struct ProcessSequencesParams {
 		address[] stakeOwners;

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -90,7 +90,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		getCommitteeContract().memberReadyToSync(sender, false);
 	}
 
-	function onlyWhenActive(address delegator, uint256 delegatorSelfStake, address newDelegate, address prevDelegate, uint256 prevDelegateNewTotalStake, uint256 newDelegateNewTotalStake, uint256 prevDelegatePrevTotalStake, bool prevSelfDelegatingPrevDelegate, uint256 newDelegatePrevTotalStake, bool prevSelfDelegatingNewDelegate) onlyDelegationsContract onlyWhenUnlocked external {
+	function notifyDelegationChange(address delegator, uint256 delegatorSelfStake, address newDelegate, address prevDelegate, uint256 prevDelegateNewTotalStake, uint256 newDelegateNewTotalStake, uint256 prevDelegatePrevTotalStake, bool prevSelfDelegatingPrevDelegate, uint256 newDelegatePrevTotalStake, bool prevSelfDelegatingNewDelegate) onlyDelegationsContract onlyWhenUnlocked external {
 		require(newDelegate != prevDelegate, "in a delegation change the delegate must change");
 
 		uint256 tempTotalGovernanceStake = totalGovernanceStake;
@@ -163,7 +163,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 			|| (isVoteeCompliant && totalCompliantStake > 0 && totalCompliantVoteOutStake.mul(100).div(totalCompliantStake) >= voteOutPercentageThreshold);
 	}
 
-	function onlyWhenActive(address addr) external onlyWhenUnlocked {
+	function voteOut(address addr) external onlyWhenUnlocked {
 		address sender = getMainAddrFromOrbsAddr(msg.sender);
 		voteOuts[sender][addr] = now;
 		emit VoteOut(sender, addr);
@@ -178,7 +178,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		}
 	}
 
-	function onlyWhenActive(address[] calldata validators) external onlyWhenUnlocked {
+	function setBanningVotes(address[] calldata validators) external onlyWhenUnlocked {
 		require(validators.length <= 3, "up to 3 concurrent votes are supported");
 		for (uint i = 0; i < validators.length; i++) {
 			require(validators[i] != address(0), "all votes must non zero addresses");
@@ -282,7 +282,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		return bannedValidators[addr] != 0;
 	}
 
-	function onlyWhenActive(uint256 prevDelegateTotalStake, uint256 newDelegateTotalStake, address delegate, bool isSelfDelegatingDelegate) external onlyDelegationsContract onlyWhenUnlocked {
+	function notifyStakeChange(uint256 prevDelegateTotalStake, uint256 newDelegateTotalStake, address delegate, bool isSelfDelegatingDelegate) external onlyDelegationsContract onlyWhenUnlocked {
 
 		uint256 prevGovStakeDelegate = calcGovernanceEffectiveStake(isSelfDelegatingDelegate, prevDelegateTotalStake);
 		uint256 newGovStakeDelegate = calcGovernanceEffectiveStake(isSelfDelegatingDelegate, newDelegateTotalStake);
@@ -299,7 +299,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		totalGovernanceStake = _totalGovernanceStake;
 	}
 
-	function onlyWhenActive(uint256[] calldata prevDelegateTotalStakes, uint256[] calldata newDelegateTotalStakes, address[] calldata delegates, bool[] calldata isSelfDelegatingDelegates) external onlyDelegationsContract onlyWhenUnlocked {
+	function notifyStakeChangeBatch(uint256[] calldata prevDelegateTotalStakes, uint256[] calldata newDelegateTotalStakes, address[] calldata delegates, bool[] calldata isSelfDelegatingDelegates) external onlyDelegationsContract onlyWhenUnlocked {
 		require(prevDelegateTotalStakes.length == newDelegateTotalStakes.length, "arrays must be of same length");
 		require(prevDelegateTotalStakes.length == delegates.length, "arrays must be of same length");
 		require(prevDelegateTotalStakes.length == isSelfDelegatingDelegates.length, "arrays must be of same length");

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -90,7 +90,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		getCommitteeContract().memberReadyToSync(sender, false);
 	}
 
-	function notifyDelegationChange(address delegator, uint256 delegatorSelfStake, address newDelegate, address prevDelegate, uint256 prevDelegateNewTotalStake, uint256 newDelegateNewTotalStake, uint256 prevDelegatePrevTotalStake, bool prevSelfDelegatingPrevDelegate, uint256 newDelegatePrevTotalStake, bool prevSelfDelegatingNewDelegate) onlyDelegationsContract external {
+	function notifyDelegationChange(address delegator, uint256 delegatorSelfStake, address newDelegate, address prevDelegate, uint256 prevDelegateNewTotalStake, uint256 newDelegateNewTotalStake, uint256 prevDelegatePrevTotalStake, bool prevSelfDelegatingPrevDelegate, uint256 newDelegatePrevTotalStake, bool prevSelfDelegatingNewDelegate) onlyDelegationsContract onlyWhenUnlocked external {
 		require(newDelegate != prevDelegate, "in a delegation change the delegate must change");
 
 		uint256 tempTotalGovernanceStake = totalGovernanceStake;
@@ -163,7 +163,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 			|| (isVoteeCompliant && totalCompliantStake > 0 && totalCompliantVoteOutStake.mul(100).div(totalCompliantStake) >= voteOutPercentageThreshold);
 	}
 
-	function voteOut(address addr) external {
+	function voteOut(address addr) external onlyWhenUnlocked {
 		address sender = getMainAddrFromOrbsAddr(msg.sender);
 		voteOuts[sender][addr] = now;
 		emit VoteOut(sender, addr);
@@ -178,7 +178,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		}
 	}
 
-	function setBanningVotes(address[] calldata validators) external {
+	function setBanningVotes(address[] calldata validators) external onlyWhenUnlocked {
 		require(validators.length <= 3, "up to 3 concurrent votes are supported");
 		for (uint i = 0; i < validators.length; i++) {
 			require(validators[i] != address(0), "all votes must non zero addresses");
@@ -278,11 +278,11 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
         }
     }
 
-	function _isBanned(address addr) private view returns (bool){
+	function _isBanned(address addr) private view returns (bool) {
 		return bannedValidators[addr] != 0;
 	}
 
-	function notifyStakeChange(uint256 prevDelegateTotalStake, uint256 newDelegateTotalStake, address delegate, bool isSelfDelegatingDelegate) external onlyDelegationsContract {
+	function notifyStakeChange(uint256 prevDelegateTotalStake, uint256 newDelegateTotalStake, address delegate, bool isSelfDelegatingDelegate) external onlyDelegationsContract onlyWhenUnlocked {
 
 		uint256 prevGovStakeDelegate = calcGovernanceEffectiveStake(isSelfDelegatingDelegate, prevDelegateTotalStake);
 		uint256 newGovStakeDelegate = calcGovernanceEffectiveStake(isSelfDelegatingDelegate, newDelegateTotalStake);
@@ -299,7 +299,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		totalGovernanceStake = _totalGovernanceStake;
 	}
 
-	function notifyStakeChangeBatch(uint256[] calldata prevDelegateTotalStakes, uint256[] calldata newDelegateTotalStakes, address[] calldata delegates, bool[] calldata isSelfDelegatingDelegates) external onlyDelegationsContract {
+	function notifyStakeChangeBatch(uint256[] calldata prevDelegateTotalStakes, uint256[] calldata newDelegateTotalStakes, address[] calldata delegates, bool[] calldata isSelfDelegatingDelegates) external onlyDelegationsContract onlyWhenUnlocked {
 		require(prevDelegateTotalStakes.length == newDelegateTotalStakes.length, "arrays must be of same length");
 		require(prevDelegateTotalStakes.length == delegates.length, "arrays must be of same length");
 		require(prevDelegateTotalStakes.length == isSelfDelegatingDelegates.length, "arrays must be of same length");

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -14,7 +14,7 @@ import "./ContractRegistryAccessor.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 
 
-contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctionalOwnership {
+contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
 	using SafeMath for uint256;
 
 	mapping (address => mapping (address => uint256)) voteOuts; // by => to => timestamp

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -90,7 +90,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		getCommitteeContract().memberReadyToSync(sender, false);
 	}
 
-	function notifyDelegationChange(address delegator, uint256 delegatorSelfStake, address newDelegate, address prevDelegate, uint256 prevDelegateNewTotalStake, uint256 newDelegateNewTotalStake, uint256 prevDelegatePrevTotalStake, bool prevSelfDelegatingPrevDelegate, uint256 newDelegatePrevTotalStake, bool prevSelfDelegatingNewDelegate) onlyDelegationsContract onlyWhenUnlocked external {
+	function notifyDelegationChange(address delegator, uint256 delegatorSelfStake, address newDelegate, address prevDelegate, uint256 prevDelegateNewTotalStake, uint256 newDelegateNewTotalStake, uint256 prevDelegatePrevTotalStake, bool prevSelfDelegatingPrevDelegate, uint256 newDelegatePrevTotalStake, bool prevSelfDelegatingNewDelegate) onlyDelegationsContract onlyWhenActive external {
 		require(newDelegate != prevDelegate, "in a delegation change the delegate must change");
 
 		uint256 tempTotalGovernanceStake = totalGovernanceStake;
@@ -163,7 +163,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 			|| (isVoteeCompliant && totalCompliantStake > 0 && totalCompliantVoteOutStake.mul(100).div(totalCompliantStake) >= voteOutPercentageThreshold);
 	}
 
-	function voteOut(address addr) external onlyWhenUnlocked {
+	function voteOut(address addr) external onlyWhenActive {
 		address sender = getMainAddrFromOrbsAddr(msg.sender);
 		voteOuts[sender][addr] = now;
 		emit VoteOut(sender, addr);
@@ -178,7 +178,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		}
 	}
 
-	function setBanningVotes(address[] calldata validators) external onlyWhenUnlocked {
+	function setBanningVotes(address[] calldata validators) external onlyWhenActive {
 		require(validators.length <= 3, "up to 3 concurrent votes are supported");
 		for (uint i = 0; i < validators.length; i++) {
 			require(validators[i] != address(0), "all votes must non zero addresses");
@@ -282,7 +282,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		return bannedValidators[addr] != 0;
 	}
 
-	function notifyStakeChange(uint256 prevDelegateTotalStake, uint256 newDelegateTotalStake, address delegate, bool isSelfDelegatingDelegate) external onlyDelegationsContract onlyWhenUnlocked {
+	function notifyStakeChange(uint256 prevDelegateTotalStake, uint256 newDelegateTotalStake, address delegate, bool isSelfDelegatingDelegate) external onlyDelegationsContract onlyWhenActive {
 
 		uint256 prevGovStakeDelegate = calcGovernanceEffectiveStake(isSelfDelegatingDelegate, prevDelegateTotalStake);
 		uint256 newGovStakeDelegate = calcGovernanceEffectiveStake(isSelfDelegatingDelegate, newDelegateTotalStake);
@@ -299,7 +299,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		totalGovernanceStake = _totalGovernanceStake;
 	}
 
-	function notifyStakeChangeBatch(uint256[] calldata prevDelegateTotalStakes, uint256[] calldata newDelegateTotalStakes, address[] calldata delegates, bool[] calldata isSelfDelegatingDelegates) external onlyDelegationsContract onlyWhenUnlocked {
+	function notifyStakeChangeBatch(uint256[] calldata prevDelegateTotalStakes, uint256[] calldata newDelegateTotalStakes, address[] calldata delegates, bool[] calldata isSelfDelegatingDelegates) external onlyDelegationsContract onlyWhenActive {
 		require(prevDelegateTotalStakes.length == newDelegateTotalStakes.length, "arrays must be of same length");
 		require(prevDelegateTotalStakes.length == delegates.length, "arrays must be of same length");
 		require(prevDelegateTotalStakes.length == isSelfDelegatingDelegates.length, "arrays must be of same length");

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -90,7 +90,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		getCommitteeContract().memberReadyToSync(sender, false);
 	}
 
-	function notifyDelegationChange(address delegator, uint256 delegatorSelfStake, address newDelegate, address prevDelegate, uint256 prevDelegateNewTotalStake, uint256 newDelegateNewTotalStake, uint256 prevDelegatePrevTotalStake, bool prevSelfDelegatingPrevDelegate, uint256 newDelegatePrevTotalStake, bool prevSelfDelegatingNewDelegate) onlyDelegationsContract onlyWhenUnlocked external {
+	function onlyWhenActive(address delegator, uint256 delegatorSelfStake, address newDelegate, address prevDelegate, uint256 prevDelegateNewTotalStake, uint256 newDelegateNewTotalStake, uint256 prevDelegatePrevTotalStake, bool prevSelfDelegatingPrevDelegate, uint256 newDelegatePrevTotalStake, bool prevSelfDelegatingNewDelegate) onlyDelegationsContract onlyWhenUnlocked external {
 		require(newDelegate != prevDelegate, "in a delegation change the delegate must change");
 
 		uint256 tempTotalGovernanceStake = totalGovernanceStake;
@@ -163,7 +163,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 			|| (isVoteeCompliant && totalCompliantStake > 0 && totalCompliantVoteOutStake.mul(100).div(totalCompliantStake) >= voteOutPercentageThreshold);
 	}
 
-	function voteOut(address addr) external onlyWhenUnlocked {
+	function onlyWhenActive(address addr) external onlyWhenUnlocked {
 		address sender = getMainAddrFromOrbsAddr(msg.sender);
 		voteOuts[sender][addr] = now;
 		emit VoteOut(sender, addr);
@@ -178,7 +178,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		}
 	}
 
-	function setBanningVotes(address[] calldata validators) external onlyWhenUnlocked {
+	function onlyWhenActive(address[] calldata validators) external onlyWhenUnlocked {
 		require(validators.length <= 3, "up to 3 concurrent votes are supported");
 		for (uint i = 0; i < validators.length; i++) {
 			require(validators[i] != address(0), "all votes must non zero addresses");
@@ -282,7 +282,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		return bannedValidators[addr] != 0;
 	}
 
-	function notifyStakeChange(uint256 prevDelegateTotalStake, uint256 newDelegateTotalStake, address delegate, bool isSelfDelegatingDelegate) external onlyDelegationsContract onlyWhenUnlocked {
+	function onlyWhenActive(uint256 prevDelegateTotalStake, uint256 newDelegateTotalStake, address delegate, bool isSelfDelegatingDelegate) external onlyDelegationsContract onlyWhenUnlocked {
 
 		uint256 prevGovStakeDelegate = calcGovernanceEffectiveStake(isSelfDelegatingDelegate, prevDelegateTotalStake);
 		uint256 newGovStakeDelegate = calcGovernanceEffectiveStake(isSelfDelegatingDelegate, newDelegateTotalStake);
@@ -299,7 +299,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		totalGovernanceStake = _totalGovernanceStake;
 	}
 
-	function notifyStakeChangeBatch(uint256[] calldata prevDelegateTotalStakes, uint256[] calldata newDelegateTotalStakes, address[] calldata delegates, bool[] calldata isSelfDelegatingDelegates) external onlyDelegationsContract onlyWhenUnlocked {
+	function onlyWhenActive(uint256[] calldata prevDelegateTotalStakes, uint256[] calldata newDelegateTotalStakes, address[] calldata delegates, bool[] calldata isSelfDelegatingDelegates) external onlyDelegationsContract onlyWhenUnlocked {
 		require(prevDelegateTotalStakes.length == newDelegateTotalStakes.length, "arrays must be of same length");
 		require(prevDelegateTotalStakes.length == delegates.length, "arrays must be of same length");
 		require(prevDelegateTotalStakes.length == isSelfDelegatingDelegates.length, "arrays must be of same length");

--- a/contracts/Lockable.sol
+++ b/contracts/Lockable.sol
@@ -20,7 +20,7 @@ contract Lockable is WithClaimableMigrationOwnership{
         locked = false;
     }
 
-    modifier onlyWhenActive() {
+    modifier onlyWhenUnlocked() {
         require(!locked, "contract is locked for this operation");
 
         _;

--- a/contracts/Lockable.sol
+++ b/contracts/Lockable.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.5.16;
+
+import "./WithClaimableMigrationOwnership.sol";
+
+
+/**
+ * @title Claimable
+ * @dev Extension for the Ownable contract, where the ownership needs to be claimed.
+ * This allows the new owner to accept the transfer.
+ */
+contract Lockable is WithClaimableMigrationOwnership{
+
+    bool locked;
+
+    function lock() external onlyMigrationOwner {
+        locked = true;
+    }
+
+    function unlock() external onlyMigrationOwner {
+        locked = false;
+    }
+
+    modifier onlyWhenUnlocked() {
+        require(!locked, "contract is locked for this operation");
+
+        _;
+    }
+}

--- a/contracts/Lockable.sol
+++ b/contracts/Lockable.sol
@@ -8,9 +8,10 @@ import "./WithClaimableMigrationOwnership.sol";
  * @dev Extension for the Ownable contract, where the ownership needs to be claimed.
  * This allows the new owner to accept the transfer.
  */
-contract Lockable is WithClaimableMigrationOwnership{
+contract Lockable is WithClaimableMigrationOwnership {
 
-    bool locked;
+    bool public locked;
+
     event Locked();
     event Unlocked();
 

--- a/contracts/Lockable.sol
+++ b/contracts/Lockable.sol
@@ -11,13 +11,17 @@ import "./WithClaimableMigrationOwnership.sol";
 contract Lockable is WithClaimableMigrationOwnership{
 
     bool locked;
+    event Locked();
+    event Unlocked();
 
     function lock() external onlyMigrationOwner {
         locked = true;
+        emit Locked();
     }
 
     function unlock() external onlyMigrationOwner {
         locked = false;
+        emit Unlocked();
     }
 
     modifier onlyWhenActive() {

--- a/contracts/Lockable.sol
+++ b/contracts/Lockable.sol
@@ -20,7 +20,7 @@ contract Lockable is WithClaimableMigrationOwnership{
         locked = false;
     }
 
-    modifier onlyWhenUnlocked() {
+    modifier onlyWhenActive() {
         require(!locked, "contract is locked for this operation");
 
         _;

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -24,7 +24,7 @@ contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctiona
         (, currentVersion) = checkPrevUpgrades(deploymentSubset);
     }
 
-    function createDeploymentSubset(string calldata deploymentSubset, uint256 initialProtocolVersion) external onlyFunctionalOwner {
+    function createDeploymentSubset(string calldata deploymentSubset, uint256 initialProtocolVersion) external onlyFunctionalOwner onlyWhenUnlocked {
         require(!deploymentSubsets[deploymentSubset].exists, "deployment subset already exists");
 
         deploymentSubsets[deploymentSubset].currentVersion = initialProtocolVersion;
@@ -35,7 +35,7 @@ contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctiona
         emit ProtocolVersionChanged(deploymentSubset, initialProtocolVersion, initialProtocolVersion, now); // TODO different event?
     }
 
-    function setProtocolVersion(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external onlyFunctionalOwner {
+    function setProtocolVersion(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external onlyFunctionalOwner onlyWhenUnlocked {
         require(deploymentSubsets[deploymentSubset].exists, "deployment subset does not exist");
         require(fromTimestamp > now, "a protocol update can only be scheduled for the future");
 

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -24,7 +24,7 @@ contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctiona
         (, currentVersion) = checkPrevUpgrades(deploymentSubset);
     }
 
-    function createDeploymentSubset(string calldata deploymentSubset, uint256 initialProtocolVersion) external onlyFunctionalOwner onlyWhenUnlocked {
+    function onlyWhenActive(string calldata deploymentSubset, uint256 initialProtocolVersion) external onlyFunctionalOwner onlyWhenUnlocked {
         require(!deploymentSubsets[deploymentSubset].exists, "deployment subset already exists");
 
         deploymentSubsets[deploymentSubset].currentVersion = initialProtocolVersion;
@@ -35,7 +35,7 @@ contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctiona
         emit ProtocolVersionChanged(deploymentSubset, initialProtocolVersion, initialProtocolVersion, now); // TODO different event?
     }
 
-    function setProtocolVersion(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external onlyFunctionalOwner onlyWhenUnlocked {
+    function onlyWhenActive(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external onlyFunctionalOwner onlyWhenUnlocked {
         require(deploymentSubsets[deploymentSubset].exists, "deployment subset does not exist");
         require(fromTimestamp > now, "a protocol update can only be scheduled for the future");
 

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -5,7 +5,7 @@ import "./WithClaimableFunctionalOwnership.sol";
 import "./WithClaimableMigrationOwnership.sol";
 import "./ContractRegistryAccessor.sol";
 
-contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctionalOwnership {
+contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
 
     struct DeploymentSubset {
         bool exists;

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -24,7 +24,7 @@ contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctiona
         (, currentVersion) = checkPrevUpgrades(deploymentSubset);
     }
 
-    function createDeploymentSubset(string calldata deploymentSubset, uint256 initialProtocolVersion) external onlyFunctionalOwner onlyWhenUnlocked {
+    function createDeploymentSubset(string calldata deploymentSubset, uint256 initialProtocolVersion) external onlyFunctionalOwner onlyWhenActive {
         require(!deploymentSubsets[deploymentSubset].exists, "deployment subset already exists");
 
         deploymentSubsets[deploymentSubset].currentVersion = initialProtocolVersion;
@@ -35,7 +35,7 @@ contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctiona
         emit ProtocolVersionChanged(deploymentSubset, initialProtocolVersion, initialProtocolVersion, now); // TODO different event?
     }
 
-    function setProtocolVersion(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external onlyFunctionalOwner onlyWhenUnlocked {
+    function setProtocolVersion(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external onlyFunctionalOwner onlyWhenActive {
         require(deploymentSubsets[deploymentSubset].exists, "deployment subset does not exist");
         require(fromTimestamp > now, "a protocol update can only be scheduled for the future");
 

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -24,7 +24,7 @@ contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctiona
         (, currentVersion) = checkPrevUpgrades(deploymentSubset);
     }
 
-    function onlyWhenActive(string calldata deploymentSubset, uint256 initialProtocolVersion) external onlyFunctionalOwner onlyWhenUnlocked {
+    function createDeploymentSubset(string calldata deploymentSubset, uint256 initialProtocolVersion) external onlyFunctionalOwner onlyWhenUnlocked {
         require(!deploymentSubsets[deploymentSubset].exists, "deployment subset already exists");
 
         deploymentSubsets[deploymentSubset].currentVersion = initialProtocolVersion;
@@ -35,7 +35,7 @@ contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctiona
         emit ProtocolVersionChanged(deploymentSubset, initialProtocolVersion, initialProtocolVersion, now); // TODO different event?
     }
 
-    function onlyWhenActive(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external onlyFunctionalOwner onlyWhenUnlocked {
+    function setProtocolVersion(string calldata deploymentSubset, uint256 nextVersion, uint256 fromTimestamp) external onlyFunctionalOwner onlyWhenUnlocked {
         require(deploymentSubsets[deploymentSubset].exists, "deployment subset does not exist");
         require(fromTimestamp > now, "a protocol update can only be scheduled for the future");
 

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -58,17 +58,17 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
 
     // bootstrap rewards
 
-    function setGeneralCommitteeAnnualBootstrap(uint256 annual_amount) external onlyFunctionalOwner onlyWhenUnlocked {
+    function onlyWhenActive(uint256 annual_amount) external onlyFunctionalOwner onlyWhenUnlocked {
         assignRewards();
         bootstrapAndStaking.generalCommitteeAnnualBootstrap = toUint48Granularity(annual_amount);
     }
 
-    function setComplianceCommitteeAnnualBootstrap(uint256 annual_amount) external onlyFunctionalOwner onlyWhenUnlocked {
+    function onlyWhenActive(uint256 annual_amount) external onlyFunctionalOwner onlyWhenUnlocked {
         assignRewards();
         bootstrapAndStaking.complianceCommitteeAnnualBootstrap = toUint48Granularity(annual_amount);
     }
 
-    function topUpBootstrapPool(uint256 amount) external onlyWhenUnlocked {
+    function onlyWhenActive(uint256 amount) external onlyWhenUnlocked {
         uint48 _amount48 = toUint48Granularity(amount);
         uint48 bootstrapPool = uint48(bootstrapAndStaking.bootstrapPool.add(_amount48)); // todo may overflow
         bootstrapAndStaking.bootstrapPool = bootstrapPool;
@@ -80,12 +80,12 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
         return toUint256Granularity(balances[addr].bootstrapRewards);
     }
 
-    function assignRewards() public onlyWhenUnlocked {
+    function onlyWhenActive() public onlyWhenUnlocked {
         (address[] memory committee, uint256[] memory weights, bool[] memory compliance) = getCommitteeContract().getCommittee();
         _assignRewardsToCommittee(committee, weights, compliance);
     }
 
-    function assignRewardsToCommittee(address[] calldata committee, uint256[] calldata committeeWeights, bool[] calldata compliance) external onlyCommitteeContract onlyWhenUnlocked {
+    function onlyWhenActive(address[] calldata committee, uint256[] calldata committeeWeights, bool[] calldata compliance) external onlyCommitteeContract onlyWhenUnlocked {
         _assignRewardsToCommittee(committee, committeeWeights, compliance);
     }
 
@@ -125,7 +125,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
         }
     }
 
-    function withdrawBootstrapFunds() external onlyWhenUnlocked {
+    function onlyWhenActive() external onlyWhenUnlocked {
         uint48 amount = balances[msg.sender].bootstrapRewards;
         uint48 pool = bootstrapAndStaking.bootstrapPool;
         require(amount <= pool, "not enough balance in the bootstrap pool for this withdrawal");
@@ -136,7 +136,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
 
     // staking rewards
 
-    function setAnnualStakingRewardsRate(uint256 annual_rate_in_percent_mille, uint256 annual_cap) external onlyFunctionalOwner onlyWhenUnlocked {
+    function onlyWhenActive(uint256 annual_rate_in_percent_mille, uint256 annual_cap) external onlyFunctionalOwner onlyWhenUnlocked {
         assignRewards();
         BootstrapAndStaking memory pools = bootstrapAndStaking;
         pools.annualRateInPercentMille = uint48(annual_rate_in_percent_mille);
@@ -144,7 +144,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
         bootstrapAndStaking = pools;
     }
 
-    function topUpStakingRewardsPool(uint256 amount) external onlyWhenUnlocked {
+    function onlyWhenActive(uint256 amount) external onlyWhenUnlocked {
         uint48 amount48 = toUint48Granularity(amount);
         bootstrapAndStaking.stakingPool = uint48(bootstrapAndStaking.stakingPool.add(amount48)); // todo overflow
         require(transferFrom(erc20, msg.sender, address(this), amount48), "Rewards::topUpProRataPool - insufficient allowance");
@@ -191,7 +191,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
     }
     mapping (address => DistributorBatchState) distributorBatchState;
 
-    function distributeOrbsTokenStakingRewards(uint256 totalAmount, uint256 fromBlock, uint256 toBlock, uint split, uint txIndex, address[] calldata to, uint256[] calldata amounts) external onlyWhenUnlocked {
+    function onlyWhenActive(uint256 totalAmount, uint256 fromBlock, uint256 toBlock, uint split, uint txIndex, address[] calldata to, uint256[] calldata amounts) external onlyWhenUnlocked {
         require(to.length == amounts.length, "expected to and amounts to be of same length");
         uint48 totalAmount_uint48 = toUint48Granularity(totalAmount);
         require(totalAmount == toUint256Granularity(totalAmount_uint48), "totalAmount must divide by 1e15");
@@ -307,11 +307,11 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
         }
     }
 
-    function fillGeneralFeeBuckets(uint256 amount, uint256 monthlyRate, uint256 fromTimestamp) external onlyWhenUnlocked {
+    function onlyWhenActive(uint256 amount, uint256 monthlyRate, uint256 fromTimestamp) external onlyWhenUnlocked {
         fillFeeBuckets(amount, monthlyRate, fromTimestamp, false);
     }
 
-    function fillComplianceFeeBuckets(uint256 amount, uint256 monthlyRate, uint256 fromTimestamp) external onlyWhenUnlocked {
+    function onlyWhenActive(uint256 amount, uint256 monthlyRate, uint256 fromTimestamp) external onlyWhenUnlocked {
         fillFeeBuckets(amount, monthlyRate, fromTimestamp, true);
     }
 
@@ -350,7 +350,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
         assert(_amount == 0);
     }
 
-    function withdrawFeeFunds() external onlyWhenUnlocked {
+    function onlyWhenActive() external onlyWhenUnlocked {
         uint48 amount = balances[msg.sender].fees;
         balances[msg.sender].fees = 0;
         require(transfer(erc20, msg.sender, amount), "Rewards::claimExternalTokenRewards - insufficient funds");

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -58,17 +58,17 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
 
     // bootstrap rewards
 
-    function setGeneralCommitteeAnnualBootstrap(uint256 annual_amount) external onlyFunctionalOwner onlyWhenUnlocked {
+    function setGeneralCommitteeAnnualBootstrap(uint256 annual_amount) external onlyFunctionalOwner onlyWhenActive {
         assignRewards();
         bootstrapAndStaking.generalCommitteeAnnualBootstrap = toUint48Granularity(annual_amount);
     }
 
-    function setComplianceCommitteeAnnualBootstrap(uint256 annual_amount) external onlyFunctionalOwner onlyWhenUnlocked {
+    function setComplianceCommitteeAnnualBootstrap(uint256 annual_amount) external onlyFunctionalOwner onlyWhenActive {
         assignRewards();
         bootstrapAndStaking.complianceCommitteeAnnualBootstrap = toUint48Granularity(annual_amount);
     }
 
-    function topUpBootstrapPool(uint256 amount) external onlyWhenUnlocked {
+    function topUpBootstrapPool(uint256 amount) external onlyWhenActive {
         uint48 _amount48 = toUint48Granularity(amount);
         uint48 bootstrapPool = uint48(bootstrapAndStaking.bootstrapPool.add(_amount48)); // todo may overflow
         bootstrapAndStaking.bootstrapPool = bootstrapPool;
@@ -80,12 +80,12 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
         return toUint256Granularity(balances[addr].bootstrapRewards);
     }
 
-    function assignRewards() public onlyWhenUnlocked {
+    function assignRewards() public onlyWhenActive {
         (address[] memory committee, uint256[] memory weights, bool[] memory compliance) = getCommitteeContract().getCommittee();
         _assignRewardsToCommittee(committee, weights, compliance);
     }
 
-    function assignRewardsToCommittee(address[] calldata committee, uint256[] calldata committeeWeights, bool[] calldata compliance) external onlyCommitteeContract onlyWhenUnlocked {
+    function assignRewardsToCommittee(address[] calldata committee, uint256[] calldata committeeWeights, bool[] calldata compliance) external onlyCommitteeContract onlyWhenActive {
         _assignRewardsToCommittee(committee, committeeWeights, compliance);
     }
 
@@ -119,7 +119,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
         certifiedValidatorBootstrap = generalValidatorBootstrap + toUint256Granularity(uint48(pools.complianceCommitteeAnnualBootstrap.mul(duration).div(365 days)));
     }
 
-    function withdrawBootstrapFunds() external onlyWhenUnlocked {
+    function withdrawBootstrapFunds() external onlyWhenActive {
         uint48 amount = balances[msg.sender].bootstrapRewards;
         uint48 pool = bootstrapAndStaking.bootstrapPool;
         require(amount <= pool, "not enough balance in the bootstrap pool for this withdrawal");
@@ -130,7 +130,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
 
     // staking rewards
 
-    function setAnnualStakingRewardsRate(uint256 annual_rate_in_percent_mille, uint256 annual_cap) external onlyFunctionalOwner onlyWhenUnlocked {
+    function setAnnualStakingRewardsRate(uint256 annual_rate_in_percent_mille, uint256 annual_cap) external onlyFunctionalOwner onlyWhenActive {
         assignRewards();
         BootstrapAndStaking memory pools = bootstrapAndStaking;
         pools.annualRateInPercentMille = uint48(annual_rate_in_percent_mille);
@@ -138,7 +138,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
         bootstrapAndStaking = pools;
     }
 
-    function topUpStakingRewardsPool(uint256 amount) external onlyWhenUnlocked {
+    function topUpStakingRewardsPool(uint256 amount) external onlyWhenActive {
         uint48 amount48 = toUint48Granularity(amount);
         bootstrapAndStaking.stakingPool = uint48(bootstrapAndStaking.stakingPool.add(amount48)); // todo overflow
         require(transferFrom(erc20, msg.sender, address(this), amount48), "Rewards::topUpProRataPool - insufficient allowance");
@@ -182,7 +182,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
     }
     mapping (address => DistributorBatchState) distributorBatchState;
 
-    function distributeOrbsTokenStakingRewards(uint256 totalAmount, uint256 fromBlock, uint256 toBlock, uint split, uint txIndex, address[] calldata to, uint256[] calldata amounts) external onlyWhenUnlocked {
+    function distributeOrbsTokenStakingRewards(uint256 totalAmount, uint256 fromBlock, uint256 toBlock, uint split, uint txIndex, address[] calldata to, uint256[] calldata amounts) external onlyWhenActive {
         require(to.length == amounts.length, "expected to and amounts to be of same length");
         uint48 totalAmount_uint48 = toUint48Granularity(totalAmount);
         require(totalAmount == toUint256Granularity(totalAmount_uint48), "totalAmount must divide by 1e15");
@@ -295,11 +295,11 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
         }
     }
 
-    function fillGeneralFeeBuckets(uint256 amount, uint256 monthlyRate, uint256 fromTimestamp) external onlyWhenUnlocked {
+    function fillGeneralFeeBuckets(uint256 amount, uint256 monthlyRate, uint256 fromTimestamp) external onlyWhenActive {
         fillFeeBuckets(amount, monthlyRate, fromTimestamp, false);
     }
 
-    function fillComplianceFeeBuckets(uint256 amount, uint256 monthlyRate, uint256 fromTimestamp) external onlyWhenUnlocked {
+    function fillComplianceFeeBuckets(uint256 amount, uint256 monthlyRate, uint256 fromTimestamp) external onlyWhenActive {
         fillFeeBuckets(amount, monthlyRate, fromTimestamp, true);
     }
 
@@ -338,7 +338,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
         assert(_amount == 0);
     }
 
-    function withdrawFeeFunds() external onlyWhenUnlocked {
+    function withdrawFeeFunds() external onlyWhenActive {
         uint48 amount = balances[msg.sender].fees;
         balances[msg.sender].fees = 0;
         require(transfer(erc20, msg.sender, amount), "Rewards::claimExternalTokenRewards - insufficient funds");

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -10,7 +10,7 @@ import "./ContractRegistryAccessor.sol";
 import "./Erc20AccessorWithTokenGranularity.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 
-contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGranularity, WithClaimableFunctionalOwnership {
+contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGranularity, WithClaimableFunctionalOwnership, Lockable {
     using SafeMath for uint256;
     using SafeMath for uint48; // TODO this is meaningless for overflow detection, SafeMath is only for uint256. Should still detect underflows
 

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -42,7 +42,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         erc20 = _erc20;
     }
 
-    function setVcConfigRecord(uint256 vcid, string calldata key, string calldata value) external onlyWhenUnlocked {
+    function setVcConfigRecord(uint256 vcid, string calldata key, string calldata value) external onlyWhenActive {
         require(msg.sender == virtualChains[vcid].owner, "only vc owner can set a vc config record");
         virtualChains[vcid].configRecords[key] = value;
         emit VcConfigRecordChanged(vcid, key, value);
@@ -52,13 +52,13 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         return virtualChains[vcid].configRecords[key];
     }
 
-    function addSubscriber(address addr) external onlyFunctionalOwner onlyWhenUnlocked {
+    function addSubscriber(address addr) external onlyFunctionalOwner onlyWhenActive {
         require(addr != address(0), "must provide a valid address");
 
         authorizedSubscribers[addr] = true;
     }
 
-    function createVC(string calldata tier, uint256 rate, uint256 amount, address owner, bool isCompliant, string calldata deploymentSubset) external onlyWhenUnlocked returns (uint, uint) {
+    function createVC(string calldata tier, uint256 rate, uint256 amount, address owner, bool isCompliant, string calldata deploymentSubset) external onlyWhenActive returns (uint, uint) {
         require(authorizedSubscribers[msg.sender], "must be an authorized subscriber");
         require(getProtocolContract().deploymentSubsetExists(deploymentSubset) == true, "No such deployment subset");
 
@@ -80,11 +80,11 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         return (vcid, vc.genRefTime);
     }
 
-    function extendSubscription(uint256 vcid, uint256 amount, address payer) external onlyWhenUnlocked {
+    function extendSubscription(uint256 vcid, uint256 amount, address payer) external onlyWhenActive {
         _extendSubscription(vcid, amount, payer);
     }
 
-    function setVcOwner(uint256 vcid, address owner) external onlyWhenUnlocked {
+    function setVcOwner(uint256 vcid, address owner) external onlyWhenActive {
         require(msg.sender == virtualChains[vcid].owner, "only the vc owner can transfer ownership");
 
         virtualChains[vcid].owner = owner;
@@ -107,7 +107,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         emit Payment(vcid, payer, amount, vc.tier, vc.rate);
     }
 
-    function setGenesisRefTimeDelay(uint256 newGenesisRefTimeDelay) external onlyFunctionalOwner onlyWhenUnlocked {
+    function setGenesisRefTimeDelay(uint256 newGenesisRefTimeDelay) external onlyFunctionalOwner onlyWhenActive {
         genesisRefTimeDelay = newGenesisRefTimeDelay;
     }
 

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -42,7 +42,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         erc20 = _erc20;
     }
 
-    function setVcConfigRecord(uint256 vcid, string calldata key, string calldata value) external {
+    function setVcConfigRecord(uint256 vcid, string calldata key, string calldata value) external onlyWhenUnlocked {
         require(msg.sender == virtualChains[vcid].owner, "only vc owner can set a vc config record");
         virtualChains[vcid].configRecords[key] = value;
         emit VcConfigRecordChanged(vcid, key, value);
@@ -52,13 +52,13 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         return virtualChains[vcid].configRecords[key];
     }
 
-    function addSubscriber(address addr) external onlyFunctionalOwner {
+    function addSubscriber(address addr) external onlyFunctionalOwner onlyWhenUnlocked {
         require(addr != address(0), "must provide a valid address");
 
         authorizedSubscribers[addr] = true;
     }
 
-    function createVC(string calldata tier, uint256 rate, uint256 amount, address owner, bool isCompliant, string calldata deploymentSubset) external returns (uint, uint) {
+    function createVC(string calldata tier, uint256 rate, uint256 amount, address owner, bool isCompliant, string calldata deploymentSubset) external onlyWhenUnlocked returns (uint, uint) {
         require(authorizedSubscribers[msg.sender], "must be an authorized subscriber");
         require(getProtocolContract().deploymentSubsetExists(deploymentSubset) == true, "No such deployment subset");
 
@@ -80,11 +80,11 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         return (vcid, vc.genRefTime);
     }
 
-    function extendSubscription(uint256 vcid, uint256 amount, address payer) external {
+    function extendSubscription(uint256 vcid, uint256 amount, address payer) external onlyWhenUnlocked {
         _extendSubscription(vcid, amount, payer);
     }
 
-    function setVcOwner(uint256 vcid, address owner) external {
+    function setVcOwner(uint256 vcid, address owner) external onlyWhenUnlocked {
         require(msg.sender == virtualChains[vcid].owner, "only the vc owner can transfer ownership");
 
         virtualChains[vcid].owner = owner;
@@ -107,7 +107,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         emit Payment(vcid, payer, amount, vc.tier, vc.rate);
     }
 
-    function setGenesisRefTimeDelay(uint256 newGenesisRefTimeDelay) external onlyFunctionalOwner {
+    function setGenesisRefTimeDelay(uint256 newGenesisRefTimeDelay) external onlyFunctionalOwner onlyWhenUnlocked {
         genesisRefTimeDelay = newGenesisRefTimeDelay;
     }
 

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -6,7 +6,7 @@ import "./spec_interfaces/IProtocol.sol";
 import "./ContractRegistryAccessor.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 
-contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimableFunctionalOwnership {
+contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
     using SafeMath for uint256;
 
     enum CommitteeType {

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -42,7 +42,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         erc20 = _erc20;
     }
 
-    function onlyWhenActive(uint256 vcid, string calldata key, string calldata value) external onlyWhenUnlocked {
+    function setVcConfigRecord(uint256 vcid, string calldata key, string calldata value) external onlyWhenUnlocked {
         require(msg.sender == virtualChains[vcid].owner, "only vc owner can set a vc config record");
         virtualChains[vcid].configRecords[key] = value;
         emit VcConfigRecordChanged(vcid, key, value);
@@ -52,13 +52,13 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         return virtualChains[vcid].configRecords[key];
     }
 
-    function onlyWhenActive(address addr) external onlyFunctionalOwner onlyWhenUnlocked {
+    function addSubscriber(address addr) external onlyFunctionalOwner onlyWhenUnlocked {
         require(addr != address(0), "must provide a valid address");
 
         authorizedSubscribers[addr] = true;
     }
 
-    function onlyWhenActive(string calldata tier, uint256 rate, uint256 amount, address owner, bool isCompliant, string calldata deploymentSubset) external onlyWhenUnlocked returns (uint, uint) {
+    function createVC(string calldata tier, uint256 rate, uint256 amount, address owner, bool isCompliant, string calldata deploymentSubset) external onlyWhenUnlocked returns (uint, uint) {
         require(authorizedSubscribers[msg.sender], "must be an authorized subscriber");
         require(getProtocolContract().deploymentSubsetExists(deploymentSubset) == true, "No such deployment subset");
 
@@ -80,11 +80,11 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         return (vcid, vc.genRefTime);
     }
 
-    function onlyWhenActive(uint256 vcid, uint256 amount, address payer) external onlyWhenUnlocked {
+    function extendSubscription(uint256 vcid, uint256 amount, address payer) external onlyWhenUnlocked {
         _extendSubscription(vcid, amount, payer);
     }
 
-    function onlyWhenActive(uint256 vcid, address owner) external onlyWhenUnlocked {
+    function setVcOwner(uint256 vcid, address owner) external onlyWhenUnlocked {
         require(msg.sender == virtualChains[vcid].owner, "only the vc owner can transfer ownership");
 
         virtualChains[vcid].owner = owner;
@@ -107,7 +107,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         emit Payment(vcid, payer, amount, vc.tier, vc.rate);
     }
 
-    function onlyWhenActive(uint256 newGenesisRefTimeDelay) external onlyFunctionalOwner onlyWhenUnlocked {
+    function setGenesisRefTimeDelay(uint256 newGenesisRefTimeDelay) external onlyFunctionalOwner onlyWhenUnlocked {
         genesisRefTimeDelay = newGenesisRefTimeDelay;
     }
 

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -42,7 +42,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         erc20 = _erc20;
     }
 
-    function setVcConfigRecord(uint256 vcid, string calldata key, string calldata value) external onlyWhenUnlocked {
+    function onlyWhenActive(uint256 vcid, string calldata key, string calldata value) external onlyWhenUnlocked {
         require(msg.sender == virtualChains[vcid].owner, "only vc owner can set a vc config record");
         virtualChains[vcid].configRecords[key] = value;
         emit VcConfigRecordChanged(vcid, key, value);
@@ -52,13 +52,13 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         return virtualChains[vcid].configRecords[key];
     }
 
-    function addSubscriber(address addr) external onlyFunctionalOwner onlyWhenUnlocked {
+    function onlyWhenActive(address addr) external onlyFunctionalOwner onlyWhenUnlocked {
         require(addr != address(0), "must provide a valid address");
 
         authorizedSubscribers[addr] = true;
     }
 
-    function createVC(string calldata tier, uint256 rate, uint256 amount, address owner, bool isCompliant, string calldata deploymentSubset) external onlyWhenUnlocked returns (uint, uint) {
+    function onlyWhenActive(string calldata tier, uint256 rate, uint256 amount, address owner, bool isCompliant, string calldata deploymentSubset) external onlyWhenUnlocked returns (uint, uint) {
         require(authorizedSubscribers[msg.sender], "must be an authorized subscriber");
         require(getProtocolContract().deploymentSubsetExists(deploymentSubset) == true, "No such deployment subset");
 
@@ -80,11 +80,11 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         return (vcid, vc.genRefTime);
     }
 
-    function extendSubscription(uint256 vcid, uint256 amount, address payer) external onlyWhenUnlocked {
+    function onlyWhenActive(uint256 vcid, uint256 amount, address payer) external onlyWhenUnlocked {
         _extendSubscription(vcid, amount, payer);
     }
 
-    function setVcOwner(uint256 vcid, address owner) external onlyWhenUnlocked {
+    function onlyWhenActive(uint256 vcid, address owner) external onlyWhenUnlocked {
         require(msg.sender == virtualChains[vcid].owner, "only the vc owner can transfer ownership");
 
         virtualChains[vcid].owner = owner;
@@ -107,7 +107,7 @@ contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimabl
         emit Payment(vcid, payer, amount, vc.tier, vc.rate);
     }
 
-    function setGenesisRefTimeDelay(uint256 newGenesisRefTimeDelay) external onlyFunctionalOwner onlyWhenUnlocked {
+    function onlyWhenActive(uint256 newGenesisRefTimeDelay) external onlyFunctionalOwner onlyWhenUnlocked {
         genesisRefTimeDelay = newGenesisRefTimeDelay;
     }
 

--- a/contracts/ValidatorsRegistration.sol
+++ b/contracts/ValidatorsRegistration.sol
@@ -33,7 +33,7 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
      */
 
     /// @dev Called by a participant who wishes to register as a validator
-	function onlyWhenActive(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyWhenUnlocked {
+	function registerValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyWhenUnlocked {
 		require(!isRegistered(msg.sender), "registerValidator: Validator is already registered");
 		validators[msg.sender].registrationTime = now;
 		_updateValidator(ip, orbsAddr, name, website, contact);
@@ -43,13 +43,13 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
 	}
 
     /// @dev Called by a participant who wishes to update its propertires
-	function onlyWhenActive(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyRegisteredValidator onlyWhenUnlocked {
+	function updateValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyRegisteredValidator onlyWhenUnlocked {
 		_updateValidator(ip, orbsAddr, name, website, contact);
 		emit ValidatorDataUpdated(msg.sender, ip, orbsAddr, name, website, contact);
 	}
 
     /// @dev Called by a prticipant to update additional validator metadata properties.
-    function onlyWhenActive(string calldata key, string calldata value) external onlyRegisteredValidator onlyWhenUnlocked {
+    function setMetadata(string calldata key, string calldata value) external onlyRegisteredValidator onlyWhenUnlocked {
 		string memory oldValue = validators[msg.sender].validatorMetadata[key];
 		validators[msg.sender].validatorMetadata[key] = value;
 		emit ValidatorMetadataChanged(msg.sender, key, value, oldValue);
@@ -61,7 +61,7 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
 	}
 
 	/// @dev Called by a participant who wishes to unregister
-	function onlyWhenActive() external onlyRegisteredValidator onlyWhenUnlocked {
+	function unregisterValidator() external onlyRegisteredValidator onlyWhenUnlocked {
 		delete orbsAddressToEthereumAddress[validators[msg.sender].orbsAddr];
 		delete ipToValidator[validators[msg.sender].ip];
 		delete validators[msg.sender];

--- a/contracts/ValidatorsRegistration.sol
+++ b/contracts/ValidatorsRegistration.sol
@@ -5,7 +5,7 @@ import "./interfaces/IElections.sol";
 import "./ContractRegistryAccessor.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 
-contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAccessor, WithClaimableFunctionalOwnership {
+contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
 
 	modifier onlyRegisteredValidator {
 		require(isRegistered(msg.sender), "Validator is not registered");

--- a/contracts/ValidatorsRegistration.sol
+++ b/contracts/ValidatorsRegistration.sol
@@ -33,7 +33,7 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
      */
 
     /// @dev Called by a participant who wishes to register as a validator
-	function registerValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyWhenUnlocked {
+	function onlyWhenActive(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyWhenUnlocked {
 		require(!isRegistered(msg.sender), "registerValidator: Validator is already registered");
 		validators[msg.sender].registrationTime = now;
 		_updateValidator(ip, orbsAddr, name, website, contact);
@@ -43,13 +43,13 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
 	}
 
     /// @dev Called by a participant who wishes to update its propertires
-	function updateValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyRegisteredValidator onlyWhenUnlocked {
+	function onlyWhenActive(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyRegisteredValidator onlyWhenUnlocked {
 		_updateValidator(ip, orbsAddr, name, website, contact);
 		emit ValidatorDataUpdated(msg.sender, ip, orbsAddr, name, website, contact);
 	}
 
     /// @dev Called by a prticipant to update additional validator metadata properties.
-    function setMetadata(string calldata key, string calldata value) external onlyRegisteredValidator onlyWhenUnlocked {
+    function onlyWhenActive(string calldata key, string calldata value) external onlyRegisteredValidator onlyWhenUnlocked {
 		string memory oldValue = validators[msg.sender].validatorMetadata[key];
 		validators[msg.sender].validatorMetadata[key] = value;
 		emit ValidatorMetadataChanged(msg.sender, key, value, oldValue);
@@ -61,7 +61,7 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
 	}
 
 	/// @dev Called by a participant who wishes to unregister
-	function unregisterValidator() external onlyRegisteredValidator onlyWhenUnlocked {
+	function onlyWhenActive() external onlyRegisteredValidator onlyWhenUnlocked {
 		delete orbsAddressToEthereumAddress[validators[msg.sender].orbsAddr];
 		delete ipToValidator[validators[msg.sender].ip];
 		delete validators[msg.sender];

--- a/contracts/ValidatorsRegistration.sol
+++ b/contracts/ValidatorsRegistration.sol
@@ -33,7 +33,7 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
      */
 
     /// @dev Called by a participant who wishes to register as a validator
-	function registerValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyWhenUnlocked {
+	function registerValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyWhenActive {
 		require(!isRegistered(msg.sender), "registerValidator: Validator is already registered");
 		validators[msg.sender].registrationTime = now;
 		_updateValidator(ip, orbsAddr, name, website, contact);
@@ -43,13 +43,13 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
 	}
 
     /// @dev Called by a participant who wishes to update its propertires
-	function updateValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyRegisteredValidator onlyWhenUnlocked {
+	function updateValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyRegisteredValidator onlyWhenActive {
 		_updateValidator(ip, orbsAddr, name, website, contact);
 		emit ValidatorDataUpdated(msg.sender, ip, orbsAddr, name, website, contact);
 	}
 
     /// @dev Called by a prticipant to update additional validator metadata properties.
-    function setMetadata(string calldata key, string calldata value) external onlyRegisteredValidator onlyWhenUnlocked {
+    function setMetadata(string calldata key, string calldata value) external onlyRegisteredValidator onlyWhenActive {
 		string memory oldValue = validators[msg.sender].validatorMetadata[key];
 		validators[msg.sender].validatorMetadata[key] = value;
 		emit ValidatorMetadataChanged(msg.sender, key, value, oldValue);
@@ -61,7 +61,7 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
 	}
 
 	/// @dev Called by a participant who wishes to unregister
-	function unregisterValidator() external onlyRegisteredValidator onlyWhenUnlocked {
+	function unregisterValidator() external onlyRegisteredValidator onlyWhenActive {
 		delete orbsAddressToEthereumAddress[validators[msg.sender].orbsAddr];
 		delete ipToValidator[validators[msg.sender].ip];
 		delete validators[msg.sender];

--- a/contracts/ValidatorsRegistration.sol
+++ b/contracts/ValidatorsRegistration.sol
@@ -33,7 +33,7 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
      */
 
     /// @dev Called by a participant who wishes to register as a validator
-	function registerValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external {
+	function registerValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyWhenUnlocked {
 		require(!isRegistered(msg.sender), "registerValidator: Validator is already registered");
 		validators[msg.sender].registrationTime = now;
 		_updateValidator(ip, orbsAddr, name, website, contact);
@@ -43,13 +43,13 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
 	}
 
     /// @dev Called by a participant who wishes to update its propertires
-	function updateValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyRegisteredValidator {
+	function updateValidator(bytes4 ip, address orbsAddr, string calldata name, string calldata website, string calldata contact) external onlyRegisteredValidator onlyWhenUnlocked {
 		_updateValidator(ip, orbsAddr, name, website, contact);
 		emit ValidatorDataUpdated(msg.sender, ip, orbsAddr, name, website, contact);
 	}
 
     /// @dev Called by a prticipant to update additional validator metadata properties.
-    function setMetadata(string calldata key, string calldata value) external onlyRegisteredValidator {
+    function setMetadata(string calldata key, string calldata value) external onlyRegisteredValidator onlyWhenUnlocked {
 		string memory oldValue = validators[msg.sender].validatorMetadata[key];
 		validators[msg.sender].validatorMetadata[key] = value;
 		emit ValidatorMetadataChanged(msg.sender, key, value, oldValue);
@@ -61,7 +61,7 @@ contract ValidatorsRegistration is IValidatorsRegistration, ContractRegistryAcce
 	}
 
 	/// @dev Called by a participant who wishes to unregister
-	function unregisterValidator() external onlyRegisteredValidator {
+	function unregisterValidator() external onlyRegisteredValidator onlyWhenUnlocked {
 		delete orbsAddressToEthereumAddress[validators[msg.sender].orbsAddr];
 		delete ipToValidator[validators[msg.sender].ip];
 		delete validators[msg.sender];

--- a/test/event-parsing.ts
+++ b/test/event-parsing.ts
@@ -58,5 +58,7 @@ export const banningVoteEvents = (txResult, contractAddress?: string) => parseLo
 export const electionsBanned = (txResult, contractAddress?: string) => parseLogs(txResult, elections, "Banned(address)", contractAddress);
 export const electionsUnbanned = (txResult, contractAddress?: string) => parseLogs(txResult, elections, "Unbanned(address)", contractAddress);
 export const validatorComplianceUpdateEvents = (txResult, contractAddress?: string) => parseLogs(txResult, compliance, "ValidatorComplianceUpdate(address,bool)", contractAddress);
+export const lockedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, protocol, "Locked()", contractAddress);
+export const unlockedEvents = (txResult, contractAddress?: string) => parseLogs(txResult, protocol, "Unlocked()", contractAddress);
 
 export const gasReportEvents = (txResult, contractAddress?: string) => parseLogs(txResult, elections, "GasReport(string,uint256)", contractAddress);

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -34,11 +34,7 @@ import {
   voteOutTimeoutSecondsChangedEvents,
   maxDelegationRatioChangedEvents,
   banningLockTimeoutSecondsChangedEvents,
-  voteOutPercentageThresholdChangedEvents, banningPercentageThresholdChangedEvents
-  validatorMetadataChangedEvents,
-  committeeChangedEvents,
-  standbysChangedEvents,
-  stakingRewardsDistributed,
+  voteOutPercentageThresholdChangedEvents, banningPercentageThresholdChangedEvents,
   lockedEvents,
   unlockedEvents
 } from "./event-parsing";

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -211,6 +211,11 @@ module.exports = function(chai) {
   chai.Assertion.overwriteMethod("contractAddressUpdatedEvent", containEvent(contractAddressUpdatedEvents));
   chai.Assertion.overwriteMethod("protocolChangedEvent", containEvent(protocolChangedEvents));
   chai.Assertion.overwriteMethod("validatorComplianceUpdateEvent", containEvent(validatorComplianceUpdateEvents));
+  chai.Assertion.overwriteMethod("voteOutTimeoutSecondsChangedEvent", containEvent(voteOutTimeoutSecondsChangedEvents));
+  chai.Assertion.overwriteMethod("maxDelegationRatioChangedEvent", containEvent(maxDelegationRatioChangedEvents));
+  chai.Assertion.overwriteMethod("banningLockTimeoutSecondsChangedEvent", containEvent(banningLockTimeoutSecondsChangedEvents));
+  chai.Assertion.overwriteMethod("voteOutPercentageThresholdChangedEvent", containEvent(voteOutPercentageThresholdChangedEvents));
+  chai.Assertion.overwriteMethod("banningPercentageThresholdChangedEvent", containEvent(banningPercentageThresholdChangedEvents));
 
   chai.Assertion.overwriteMethod("haveCommittee", containEvent(function(o) {return [o];}));
 

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -216,6 +216,8 @@ module.exports = function(chai) {
   chai.Assertion.overwriteMethod("banningLockTimeoutSecondsChangedEvent", containEvent(banningLockTimeoutSecondsChangedEvents));
   chai.Assertion.overwriteMethod("voteOutPercentageThresholdChangedEvent", containEvent(voteOutPercentageThresholdChangedEvents));
   chai.Assertion.overwriteMethod("banningPercentageThresholdChangedEvent", containEvent(banningPercentageThresholdChangedEvents));
+  chai.Assertion.overwriteMethod("lockedEvent", containEvent(lockedEvents));
+  chai.Assertion.overwriteMethod("unlockedEvent", containEvent(unlockedEvents));
 
   chai.Assertion.overwriteMethod("haveCommittee", containEvent(function(o) {return [o];}));
 

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -27,7 +27,12 @@ import {
   validatorRegisteredEvents,
   validatorUnregisteredEvents,
   validatorDataUpdatedEvents,
-  validatorMetadataChangedEvents, committeeChangedEvents, standbysChangedEvents, stakingRewardsDistributed
+  validatorMetadataChangedEvents,
+  committeeChangedEvents,
+  standbysChangedEvents,
+  stakingRewardsDistributed,
+  lockedEvents,
+  unlockedEvents
 } from "./event-parsing";
 import * as _ from "lodash";
 import chai from "chai";
@@ -61,6 +66,7 @@ import {
 import {CommitteeChangedEvent, StandbysChangedEvent} from "../typings/committee-contract";
 import {ValidatorComplianceUpdateEvent} from "../typings/compliance-contract";
 import {Contract} from "../eth";
+import {LockedEvent, UnlockedEvent} from "../typings/base-contract";
 
 export function isBNArrayEqual(a1: Array<any>, a2: Array<any>): boolean {
   return (
@@ -198,6 +204,8 @@ module.exports = function(chai) {
   chai.Assertion.overwriteMethod("contractAddressUpdatedEvent", containEvent(contractAddressUpdatedEvents));
   chai.Assertion.overwriteMethod("protocolChangedEvent", containEvent(protocolChangedEvents));
   chai.Assertion.overwriteMethod("validatorComplianceUpdateEvent", containEvent(validatorComplianceUpdateEvents));
+  chai.Assertion.overwriteMethod("lockedEvent", containEvent(lockedEvents));
+  chai.Assertion.overwriteMethod("unlockedEvent", containEvent(unlockedEvents));
 
   chai.Assertion.overwriteMethod("haveCommittee", containEvent(function(o) {return [o];}));
 
@@ -239,6 +247,8 @@ declare global {
       feesAddedToBucketEvent(data?: Partial<FeesAddedToBucketEvent>);
       bootstrapRewardsAssignedEvent(data?: Partial<BootstrapRewardsAssignedEvent>)
       bootstrapAddedToPoolEvent(data?: Partial<BootstrapAddedToPoolEvent>)
+      lockedEvent(data?: Partial<LockedEvent>);
+      unlockedEvent(data?: Partial<UnlockedEvent>);
       withinContract(contract: Contract): Assertion;
     }
 

--- a/test/protocol-lockdown.spec.ts
+++ b/test/protocol-lockdown.spec.ts
@@ -1,0 +1,45 @@
+import 'mocha';
+
+
+import BN from "bn.js";
+import {Driver, DEPLOYMENT_SUBSET_MAIN, DEPLOYMENT_SUBSET_CANARY, expectRejected} from "./driver";
+import chai from "chai";
+
+chai.use(require('chai-bn')(BN));
+chai.use(require('./matchers'));
+
+const expect = chai.expect;
+
+import {bn, evmIncreaseTimeForQueries, getTopBlockTimestamp} from "./helpers";
+
+describe.only('protocol-contract', async () => {
+
+  // functional owner
+
+  it('allows only the migration owner to lock and unlock the contract', async () => {
+    const d = await Driver.new();
+
+    await expectRejected(d.protocol.lock({from: d.functionalOwner.address}));
+    await d.protocol.lock({from: d.migrationOwner.address});
+    await expectRejected(d.protocol.unlock({from: d.functionalOwner.address}));
+    await d.protocol.unlock({from: d.migrationOwner.address});
+  });
+
+  it('rejects calls to createNewDeploymentSubset and setProtocolVersion when locked', async () => {
+    const d = await Driver.new();
+
+    await d.protocol.lock({from: d.migrationOwner.address});
+
+    let currTime: number = await getTopBlockTimestamp(d);
+    await expectRejected(d.protocol.createDeploymentSubset("newdeploymentsubset", 1, {from: d.functionalOwner.address}));
+    await expectRejected(d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 100, {from: d.functionalOwner.address}));
+
+    await d.protocol.unlock({from: d.migrationOwner.address});
+
+    currTime = await getTopBlockTimestamp(d);
+    await d.protocol.createDeploymentSubset("newdeploymentsubset", 1, {from: d.functionalOwner.address});
+    await d.protocol.setProtocolVersion(DEPLOYMENT_SUBSET_MAIN, 2, currTime + 100, {from: d.functionalOwner.address});
+
+  });
+
+});

--- a/test/protocol-lockdown.spec.ts
+++ b/test/protocol-lockdown.spec.ts
@@ -12,7 +12,7 @@ const expect = chai.expect;
 
 import {bn, evmIncreaseTimeForQueries, getTopBlockTimestamp} from "./helpers";
 
-describe.only('protocol-contract', async () => {
+describe('protocol-contract', async () => {
 
   // functional owner
 
@@ -20,9 +20,11 @@ describe.only('protocol-contract', async () => {
     const d = await Driver.new();
 
     await expectRejected(d.protocol.lock({from: d.functionalOwner.address}));
-    await d.protocol.lock({from: d.migrationOwner.address});
+    let r = await d.protocol.lock({from: d.migrationOwner.address});
+    expect(r).to.have.a.lockedEvent();
     await expectRejected(d.protocol.unlock({from: d.functionalOwner.address}));
-    await d.protocol.unlock({from: d.migrationOwner.address});
+    r = await d.protocol.unlock({from: d.migrationOwner.address});
+    expect(r).to.have.a.unlockedEvent();
   });
 
   it('rejects calls to createNewDeploymentSubset and setProtocolVersion when locked', async () => {

--- a/typings/base-contract.d.ts
+++ b/typings/base-contract.d.ts
@@ -7,5 +7,8 @@ export interface OwnedContract extends Contract {
     transferMigrationOwnership(newOwner: string, params?: TransactionConfig): Promise<TransactionReceipt>;
     claimMigrationOwnership(params?: TransactionConfig): Promise<TransactionReceipt>;
 
+    lock(params?: TransactionConfig): Promise<TransactionReceipt>;
+    unlock(params?: TransactionConfig): Promise<TransactionReceipt>;
+
     setContractRegistry(address: string, params?: TransactionConfig): Promise<TransactionReceipt>;
 }

--- a/typings/base-contract.d.ts
+++ b/typings/base-contract.d.ts
@@ -1,6 +1,9 @@
 import {Contract} from "../eth";
 import {TransactionConfig, TransactionReceipt} from "web3-core";
 
+export interface LockedEvent {}
+export interface UnlockedEvent {}
+
 export interface OwnedContract extends Contract {
     transferFunctionalOwnership(newOwner: string, params?: TransactionConfig): Promise<TransactionReceipt>;
     claimFunctionalOwnership(params?: TransactionConfig): Promise<TransactionReceipt>;


### PR DESCRIPTION
This allows the migration owner to lock and unlock contract methods. 
- All contract methods which modify the state of the contract are decorated with the -`onlyWhenUnlocked` modifier, which reverts if the contract is in a locked state. 
- The `Lockable` contract (which other contracts inherit from) defines this modifier and the `lock`/`unlock` methods.