### PR TITLE
TESTKIT_INTERNAL: Reduce boilerplate of event parsing

### DIFF
--- a/compiled-contracts.ts
+++ b/compiled-contracts.ts
@@ -13,4 +13,29 @@ function loadCompiledContracts(baseDir: string): CompiledContracts {
     return artifacts;
 }
 
+interface EventDefinition {
+    name: string,
+    signature: string,
+    contractName: any
+}
+
+function listEventsDefinitions(contracts: CompiledContracts): EventDefinition[] {
+    const defs: EventDefinition[] = [];
+
+    for (const contractName in contracts) {
+        const contract = contracts[contractName];
+        const eventDefs: EventDefinition[] = contract.abi
+            .filter(x => x.type == 'event')
+            .map(e => ({
+                contractName: contractName,
+                name: e.name,
+                signature: e.name + "(" + e.inputs.map(input => input.type).join(',') + ")"
+            }));
+        defs.push(...eventDefs);
+    }
+
+    return defs;
+}
+
 export const compiledContracts = loadCompiledContracts(path.join(__dirname, 'build', 'contracts'));
+export const eventDefinitions = listEventsDefinitions(compiledContracts);

--- a/compiled-contracts.ts
+++ b/compiled-contracts.ts
@@ -3,9 +3,13 @@ import * as path from "path";
 
 export type CompiledContracts = {[contractName: string]: any};
 
+const EXCLUDE = ["IElections.json"];
+
 function loadCompiledContracts(baseDir: string): CompiledContracts {
     const artifacts: CompiledContracts = {};
     for (const fname of fs.readdirSync(baseDir)) {
+        if (EXCLUDE.includes(fname)) continue;
+
         const name = fname.replace('.json', '');
         const abi = JSON.parse(fs.readFileSync(baseDir + '/' + fname, {encoding:'utf8'}));
         artifacts[name] = abi;

--- a/test/committee.spec.ts
+++ b/test/committee.spec.ts
@@ -981,7 +981,7 @@ describe('committee', async () => {
 
         await expectRejected(d.committee.setMaxTimeBetweenRewardAssignments(maxTimeBetweenRewardAssignments.add(bn(1)), {from: d.migrationOwner.address}));
         r = await d.committee.setMaxTimeBetweenRewardAssignments(maxTimeBetweenRewardAssignments.add(bn(1)), {from: d.functionalOwner.address});
-        expect(r).to.have.a.maxTimeBetweenRewardAssignmentsChangedEvents({
+        expect(r).to.have.a.maxTimeBetweenRewardAssignmentsChangedEvent({
             newValue: maxTimeBetweenRewardAssignments.add(bn(1)).toString(),
             oldValue: maxTimeBetweenRewardAssignments.toString()
         });

--- a/test/event-parsing.ts
+++ b/test/event-parsing.ts
@@ -20,7 +20,7 @@ const protocol = compiledContracts["Protocol"];
 const contractRegistry = compiledContracts["ContractRegistry"];
 const delegations = compiledContracts["Delegations"];
 
-function parseLogs(txResult, contract, eventSignature, contractAddress?: string) {
+export function parseLogs(txResult, contract, eventSignature, contractAddress?: string) {
     const abi = new Web3().eth.abi;
     const inputs = contract.abi.find(e => e.name == eventSignature.split('(')[0]).inputs;
     const eventSignatureHash = abi.encodeEventSignature(eventSignature);

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -1,53 +1,7 @@
 import BN from "bn.js";
 
 import {
-  delegatedEvents,
-  delegatedStakeChangedEvents,
-  stakedEvents,
-  stakeChangedEvents,
-  subscriptionChangedEvents,
-  paymentEvents,
-  feesAddedToBucketEvents,
-  unstakedEvents,
-  voteOutEvents,
-  votedOutOfCommitteeEvents,
-  vcConfigRecordChangedEvents,
-  contractAddressUpdatedEvents,
-  protocolChangedEvents,
-  banningVoteEvents,
-  electionsBanned,
-  electionsUnbanned,
-  vcOwnerChangedEvents,
-  feesAssignedEvents,
-  bootstrapAddedToPoolEvents,
-  stakingRewardsAssignedEvents,
-  bootstrapRewardsAssignedEvents,
-  validatorComplianceUpdateEvents,
-  vcCreatedEvents,
-  validatorRegisteredEvents,
-  validatorUnregisteredEvents,
-  validatorDataUpdatedEvents,
-  validatorMetadataChangedEvents,
-  committeeSnapshotEvents,
-  standbysSnapshotEvents,
-  stakingRewardsDistributedEvents,
-  voteOutTimeoutSecondsChangedEvents,
-  maxDelegationRatioChangedEvents,
-  banningLockTimeoutSecondsChangedEvents,
-  voteOutPercentageThresholdChangedEvents,
-  banningPercentageThresholdChangedEvents,
-  lockedEvents,
-  unlockedEvents,
-  readyToSyncTimeoutChangedEvents,
-  maxCommitteeSizeChangedEvents,
-  maxStandbysChangedEvents,
-  contractRegistryAddressUpdatedEvents,
-  bootstrapRewardsWithdrawnEvents,
-  feesWithdrawnEvents,
-  stakingRewardsAddedToPoolEvents,
-  validatorStatusUpdatedEvents,
-  validatorCommitteeChangeEvents,
-  maxTimeBetweenRewardAssignmentsChangedEvents
+  parseLogs
 } from "./event-parsing";
 import * as _ from "lodash";
 import chai from "chai";
@@ -98,6 +52,7 @@ import {
 import {ValidatorComplianceUpdateEvent} from "../typings/compliance-contract";
 import {Contract} from "../eth";
 import {ContractRegistryAddressUpdatedEvent, LockedEvent, UnlockedEvent} from "../typings/base-contract";
+import {compiledContracts, eventDefinitions} from "../compiled-contracts";
 
 export function isBNArrayEqual(a1: Array<any>, a2: Array<any>): boolean {
   return (
@@ -148,11 +103,11 @@ function objectMatches(obj, against): boolean {
     return true;
 }
 
-function compare(event: any, against: any, transposed?: boolean, key?: string): boolean {
-  if (transposed) {
+function compare(event: any, against: any, transposeKey?: string): boolean {
+  if (transposeKey != null) {
     const fields = Object.keys(against);
-    event = transpose(event, key, fields);
-    against = transpose(against, key);
+    event = transpose(event, transposeKey, fields);
+    against = transpose(against, transposeKey);
     return  Object.keys(against).length == Object.keys(event).length &&
         Object.keys(against).find(key => !objectMatches(event[key], against[key])) == null;
   } else {
@@ -164,7 +119,7 @@ function stripEvent(event) {
   return _.pickBy(event, (v, k) => /[_0-9]/.exec(k[0]) == null);
 }
 
-const containEvent = (eventParser, transposed?: boolean, key?: string) =>
+const containEvent = (eventParser, transposeKey?: string) =>
   function(_super) {
     return function(this: any, data) {
       data = data || {};
@@ -181,7 +136,7 @@ const containEvent = (eventParser, transposed?: boolean, key?: string) =>
       if (logs.length == 1) {
         const log = logs.pop();
         this.assert(
-            compare(log, data, transposed, key),
+            compare(log, data, transposeKey),
             "expected #{this} to be #{exp} but got #{act}",
             "expected #{this} to not be #{act}",
             data, // expected
@@ -189,7 +144,7 @@ const containEvent = (eventParser, transposed?: boolean, key?: string) =>
         );
       } else {
         for (const log of logs) {
-          if (compare(log, data, transposed, key)) {
+          if (compare(log, data, transposeKey)) {
             return;
           }
         }
@@ -203,56 +158,21 @@ const containEvent = (eventParser, transposed?: boolean, key?: string) =>
     };
   };
 
-module.exports = function(chai) {
-  chai.Assertion.overwriteMethod("delegatedEvent", containEvent(delegatedEvents));
-  chai.Assertion.overwriteMethod("delegatedStakeChangedEvent", containEvent(delegatedStakeChangedEvents));
-  chai.Assertion.overwriteMethod("validatorRegisteredEvent", containEvent(validatorRegisteredEvents));
-  chai.Assertion.overwriteMethod("validatorUnregisteredEvent", containEvent(validatorUnregisteredEvents));
-  chai.Assertion.overwriteMethod("validatorDataUpdatedEvent", containEvent(validatorDataUpdatedEvents));
-  chai.Assertion.overwriteMethod("validatorMetadataChangedEvent", containEvent(validatorMetadataChangedEvents));
-  chai.Assertion.overwriteMethod("committeeSnapshotEvent", containEvent(committeeSnapshotEvents, true, 'addrs'));
-  chai.Assertion.overwriteMethod("standbysSnapshotEvent", containEvent(standbysSnapshotEvents, true, 'addrs'));
-  chai.Assertion.overwriteMethod("stakeChangedEvent", containEvent(stakeChangedEvents));
-  chai.Assertion.overwriteMethod("stakedEvent", containEvent(stakedEvents));
-  chai.Assertion.overwriteMethod("unstakedEvent", containEvent(unstakedEvents));
-  chai.Assertion.overwriteMethod("subscriptionChangedEvent", containEvent(subscriptionChangedEvents));
-  chai.Assertion.overwriteMethod("paymentEvent", containEvent(paymentEvents));
-  chai.Assertion.overwriteMethod("feeAddedToBucketEvent", containEvent(feesAddedToBucketEvents));
-  chai.Assertion.overwriteMethod("bootstrapAddedToPoolEvent", containEvent(bootstrapAddedToPoolEvents));
-  chai.Assertion.overwriteMethod("bootstrapRewardsAssignedEvent", containEvent(bootstrapRewardsAssignedEvents));
-  chai.Assertion.overwriteMethod("bootstrapRewardsWithdrawnEvent", containEvent(bootstrapRewardsWithdrawnEvents));
-  chai.Assertion.overwriteMethod("feesWithdrawnEvent", containEvent(feesWithdrawnEvents));
-  chai.Assertion.overwriteMethod("stakingRewardsAddedToPoolEvent", containEvent(stakingRewardsAddedToPoolEvents));
-  chai.Assertion.overwriteMethod("stakingRewardsAssignedEvent", containEvent(stakingRewardsAssignedEvents, true, 'assignees'));
-  chai.Assertion.overwriteMethod("stakingRewardsDistributedEvent", containEvent(stakingRewardsDistributedEvents));
-  chai.Assertion.overwriteMethod("feesAssignedEvent", containEvent(feesAssignedEvents));
-  chai.Assertion.overwriteMethod("feesAddedToBucketEvent", containEvent(feesAddedToBucketEvents));
-  chai.Assertion.overwriteMethod("voteOutEvent", containEvent(voteOutEvents));
-  chai.Assertion.overwriteMethod("votedOutOfCommitteeEvent", containEvent(votedOutOfCommitteeEvents));
-  chai.Assertion.overwriteMethod("banningVoteEvent", containEvent(banningVoteEvents));
-  chai.Assertion.overwriteMethod("bannedEvent", containEvent(electionsBanned));
-  chai.Assertion.overwriteMethod("unbannedEvent", containEvent(electionsUnbanned));
-  chai.Assertion.overwriteMethod("vcConfigRecordChangedEvent", containEvent(vcConfigRecordChangedEvents));
-  chai.Assertion.overwriteMethod("vcOwnerChangedEvent", containEvent(vcOwnerChangedEvents));
-  chai.Assertion.overwriteMethod("vcCreatedEvent", containEvent(vcCreatedEvents));
-  chai.Assertion.overwriteMethod("contractAddressUpdatedEvent", containEvent(contractAddressUpdatedEvents));
-  chai.Assertion.overwriteMethod("protocolChangedEvent", containEvent(protocolChangedEvents));
-  chai.Assertion.overwriteMethod("validatorComplianceUpdateEvent", containEvent(validatorComplianceUpdateEvents));
-  chai.Assertion.overwriteMethod("readyToSyncTimeoutChangedEvent", containEvent(readyToSyncTimeoutChangedEvents));
-  chai.Assertion.overwriteMethod("maxTimeBetweenRewardAssignmentsChangedEvents", containEvent(maxTimeBetweenRewardAssignmentsChangedEvents));
-  chai.Assertion.overwriteMethod("maxCommitteeSizeChangedEvent", containEvent(maxCommitteeSizeChangedEvents));
-  chai.Assertion.overwriteMethod("maxStandbysChangedEvent", containEvent(maxStandbysChangedEvents));
-  chai.Assertion.overwriteMethod("voteOutTimeoutSecondsChangedEvent", containEvent(voteOutTimeoutSecondsChangedEvents));
-  chai.Assertion.overwriteMethod("maxDelegationRatioChangedEvent", containEvent(maxDelegationRatioChangedEvents));
-  chai.Assertion.overwriteMethod("banningLockTimeoutSecondsChangedEvent", containEvent(banningLockTimeoutSecondsChangedEvents));
-  chai.Assertion.overwriteMethod("voteOutPercentageThresholdChangedEvent", containEvent(voteOutPercentageThresholdChangedEvents));
-  chai.Assertion.overwriteMethod("banningPercentageThresholdChangedEvent", containEvent(banningPercentageThresholdChangedEvents));
-  chai.Assertion.overwriteMethod("lockedEvent", containEvent(lockedEvents));
-  chai.Assertion.overwriteMethod("unlockedEvent", containEvent(unlockedEvents));
-  chai.Assertion.overwriteMethod("validatorStatusUpdatedEvent", containEvent(validatorStatusUpdatedEvents));
-  chai.Assertion.overwriteMethod("contractRegistryAddressUpdatedEvent", containEvent(contractRegistryAddressUpdatedEvents));
-  chai.Assertion.overwriteMethod("validatorCommitteeChangeEvent", containEvent(validatorCommitteeChangeEvents));
+const TransposeKeys = {
+  "CommitteeSnapshot": "addrs",
+  "StandbysSnapshot": "addrs",
+  "StakingRewardsAssigned": "assignees",
+};
 
+module.exports = function(chai) {
+  for (const event of eventDefinitions) {
+    chai.Assertion.overwriteMethod(event.name[0].toLowerCase() + event.name.substr(1) + 'Event',
+        containEvent(
+            (txResult, contractAddress?: string) => parseLogs(txResult, compiledContracts[event.contractName], event.signature, contractAddress),
+            TransposeKeys[event.name]
+        )
+    );
+  }
   chai.Assertion.overwriteMethod("haveCommittee", containEvent(function(o) {return [o];}));
 
   chai.Assertion.addChainableMethod("withinContract", function (this: any, contract: Contract) {

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -224,7 +224,7 @@ declare global {
       bootstrapRewardsAssignedEvent(data?: Partial<BootstrapRewardsAssignedEvent>);
       bootstrapAddedToPoolEvent(data?: Partial<BootstrapAddedToPoolEvent>);
       readyToSyncTimeoutChangedEvent(data?: Partial<ReadyToSyncTimeoutChangedEvent>);
-      maxTimeBetweenRewardAssignmentsChangedEvents(data?: Partial<MaxTimeBetweenRewardAssignmentsChangedEvent>)
+      maxTimeBetweenRewardAssignmentsChangedEvent(data?: Partial<MaxTimeBetweenRewardAssignmentsChangedEvent>)
       maxCommitteeSizeChangedEvent(data?: Partial<MaxCommitteeSizeChangedEvent>);
       maxStandbysChangedEvent(data?: Partial<MaxStandbysChangedEvent>);
       feesWithdrawnEvent(data?: Partial<FeesWithdrawnEvent>);


### PR DESCRIPTION
No need to define the event in `event-parsers.ts` and in `matchers.ts`.
(Typings still need to be added to `matchers.ts`)