### PR TITLE
ELECTIONS: readyForX can be sent from Orbs and Guardian addresses

### DIFF
--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -86,16 +86,24 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		getCommitteeContract().memberComplianceChange(addr, isCompliant);
 	}
 
-	function notifyReadyForCommittee() external onlyNotBanned {
-		address sender = getMainAddrFromOrbsAddr(msg.sender);
-		emit ValidatorStatusUpdated(sender, true, true);
-		getCommitteeContract().memberReadyToSync(sender, true);
+	function requireNotBanned(address addr) private view {
+		require(!_isBanned(addr), "caller is a banned validator");
 	}
 
-	function notifyReadyToSync() external onlyNotBanned {
-		address sender = getMainAddrFromOrbsAddr(msg.sender);
-		emit ValidatorStatusUpdated(sender, true, false);
-		getCommitteeContract().memberReadyToSync(sender, false);
+	function notifyReadyForCommittee() external {
+		address guardianAddr = getValidatorsRegistrationContract().resolveGuardianAddress(msg.sender); // this validates registration
+		requireNotBanned(guardianAddr);
+
+		emit ValidatorStatusUpdated(guardianAddr, true, true);
+		getCommitteeContract().memberReadyToSync(guardianAddr, true);
+	}
+
+	function notifyReadyToSync() external {
+		address guardianAddr = getValidatorsRegistrationContract().resolveGuardianAddress(msg.sender); // this validates registration
+		requireNotBanned(guardianAddr);
+
+		emit ValidatorStatusUpdated(guardianAddr, true, false);
+		getCommitteeContract().memberReadyToSync(guardianAddr, false);
 	}
 
 	function notifyDelegationChange(address delegator, uint256 delegatorSelfStake, address newDelegate, address prevDelegate, uint256 prevDelegateNewTotalStake, uint256 newDelegateNewTotalStake, uint256 prevDelegatePrevTotalStake, bool prevSelfDelegatingPrevDelegate, uint256 newDelegatePrevTotalStake, bool prevSelfDelegatingNewDelegate) onlyDelegationsContract onlyWhenActive external {

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -86,7 +86,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		requireNotBanned(guardianAddr);
 
 		emit ValidatorStatusUpdated(guardianAddr, true, true);
-		getCommitteeContract().memberReadyToSync(guardianAddr, true);
+        getCommitteeContract().addMember(guardianAddr, getCommitteeEffectiveStake(guardianAddr, settings), getComplianceContract().isValidatorCompliant(guardianAddr));
 	}
 
 	function notifyReadyToSync() external {
@@ -94,7 +94,7 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		requireNotBanned(guardianAddr);
 
 		emit ValidatorStatusUpdated(guardianAddr, true, false);
-		getCommitteeContract().memberReadyToSync(guardianAddr, false);
+        getCommitteeContract().removeMember(guardianAddr);
 	}
 
 	function notifyDelegationChange(address delegator, uint256 delegatorSelfStake, address newDelegate, address prevDelegate, uint256 prevDelegateNewTotalStake, uint256 newDelegateNewTotalStake, uint256 prevDelegatePrevTotalStake, bool prevSelfDelegatingPrevDelegate, uint256 newDelegatePrevTotalStake, bool prevSelfDelegatingNewDelegate) onlyDelegationsContract onlyWhenActive external {

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -45,12 +45,6 @@ contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctio
 		_;
 	}
 
-	modifier onlyNotBanned() {
-		require(!_isBanned(msg.sender), "caller is a banned validator");
-
-		_;
-	}
-
 	constructor(uint32 _maxDelegationRatio, uint8 _voteOutPercentageThreshold, uint32 _voteOutTimeoutSeconds, uint8 _banningPercentageThreshold) public {
 		require(_maxDelegationRatio >= 1, "max delegation ration must be at least 1");
 		require(_voteOutPercentageThreshold >= 0 && _voteOutPercentageThreshold <= 100, "voteOutPercentageThreshold must be between 0 and 100");

--- a/test/elections.spec.ts
+++ b/test/elections.spec.ts
@@ -42,6 +42,49 @@ describe('elections-high-level-flows', async () => {
         });
     });
 
+    it('allows sending readyForCommittee and readyToSync form both guardian and orbs address', async () => {
+        const d = await Driver.new();
+
+        const {v} = await d.newValidator(fromTokenUnits(10), false, false, false);
+
+        let r = await d.elections.notifyReadyToSync({from: v.orbsAddress});
+        expect(r).to.have.a.validatorStatusUpdatedEvent({
+            addr: v.address,
+            readyToSync: true,
+            readyForCommittee: false
+        });
+
+        r = await d.elections.notifyReadyToSync({from: v.address});
+        expect(r).to.have.a.validatorStatusUpdatedEvent({
+            addr: v.address,
+            readyToSync: true,
+            readyForCommittee: false
+        });
+
+        r = await d.elections.notifyReadyForCommittee({from: v.orbsAddress});
+        expect(r).to.have.a.validatorStatusUpdatedEvent({
+            addr: v.address,
+            readyToSync: true,
+            readyForCommittee: true
+        });
+
+        r = await d.elections.notifyReadyForCommittee({from: v.address});
+        expect(r).to.have.a.validatorStatusUpdatedEvent({
+            addr: v.address,
+            readyToSync: true,
+            readyForCommittee: true
+        });
+    });
+
+    it('rejects readyForCommittee and readyToSync from an unregistered validator', async () => {
+        const d = await Driver.new();
+
+        const v = d.newParticipant();
+
+        await expectRejected(d.elections.notifyReadyToSync({from: v.address}));
+        await expectRejected(d.elections.notifyReadyForCommittee({from: v.address}));
+    });
+
     it('handle delegation requests', async () => {
         const d = await Driver.new();
 
@@ -958,6 +1001,54 @@ describe('elections-high-level-flows', async () => {
         expect(r).to.have.a.standbysSnapshotEvent({
             addrs: []
         });
+    });
+
+    it("rejects readyToSync and readyForCommittee for a banned validator", async () => {
+        const d = await Driver.new();
+
+        let r;
+        let {thresholdCrossingIndex, delegatees, delegators, bannedValidator} = await banningScenario_setupDelegatorsAndValidators(d);
+
+        // -------------- CAST VOTES UNDER THE THRESHOLD ---------------
+
+        for (let i = 0; i < thresholdCrossingIndex; i++) {
+            const p = delegatees[i];
+            r = await d.elections.setBanningVotes([bannedValidator.address], {from: p.address});
+            expect(r).to.have.a.banningVoteEvent({
+                voter: p.address,
+                against: [bannedValidator.address]
+            });
+            expect(r).to.not.have.a.committeeSnapshotEvent();
+            expect(r).to.not.have.a.standbysSnapshotEvent();
+            expect(r).to.not.have.a.bannedEvent();
+            expect(r).to.not.have.a.unbannedEvent();
+        }
+
+        // -------------- ONE MORE VOTE TO REACH BANNING THRESHOLD ---------------
+
+        r = await d.elections.setBanningVotes([bannedValidator.address], {from: delegatees[thresholdCrossingIndex].address}); // threshold is crossed
+        expect(r).to.have.a.banningVoteEvent({
+            voter: delegatees[thresholdCrossingIndex].address,
+            against: [bannedValidator.address]
+        });
+        expect(r).to.have.a.bannedEvent({
+            validator: bannedValidator.address
+        });
+        expect(r).to.have.withinContract(d.committee).a.committeeSnapshotEvent({
+            addrs: []
+        });
+
+        await expectRejected(d.elections.notifyReadyToSync({from: bannedValidator.address}));
+        await expectRejected(d.elections.notifyReadyToSync({from: bannedValidator.orbsAddress}));
+        await expectRejected(d.elections.notifyReadyForCommittee({from: bannedValidator.address}));
+        await expectRejected(d.elections.notifyReadyForCommittee({from: bannedValidator.orbsAddress}));
+
+        await d.elections.setBanningVotes([], {from: delegatees[thresholdCrossingIndex].address}); // threshold is crossed
+
+        await d.elections.notifyReadyToSync({from: bannedValidator.address});
+        await d.elections.notifyReadyToSync({from: bannedValidator.orbsAddress});
+        await d.elections.notifyReadyForCommittee({from: bannedValidator.address});
+        await d.elections.notifyReadyForCommittee({from: bannedValidator.orbsAddress});
     });
 
     it("sets and gets settings, only functional owner allowed to set", async () => {

--- a/test/elections.spec.ts
+++ b/test/elections.spec.ts
@@ -872,7 +872,6 @@ describe('elections-high-level-flows', async () => {
                 against: [bannedValidator.address]
             });
             expect(r).to.not.have.a.committeeSnapshotEvent();
-            expect(r).to.not.have.a.standbysSnapshotEvent();
             expect(r).to.not.have.a.bannedEvent();
             expect(r).to.not.have.a.unbannedEvent();
         }


### PR DESCRIPTION
Also a bug fix - rejecting readyForX for a banned validator which used its Orbs address.