### PR TITLE
REWARDS: Easier handling of staking rewards ratio rounding error

### DIFF
--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -209,7 +209,7 @@ contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGr
     mapping (address => DistributorBatchState) distributorBatchState;
 
     function isDelegatorRewardsBelowThreshold(uint256 delegatorRewards, uint256 totalRewards) private view returns (bool) {
-        return delegatorRewards.mul(100000) <= uint(settings.maxDelegatorsStakingRewardsPercentMille).mul(totalRewards);
+        return delegatorRewards.mul(100000) <= uint(settings.maxDelegatorsStakingRewardsPercentMille).mul(totalRewards.add(toUint256Granularity(1))); // +1 is added to account for rounding errors
     }
 
     struct VistributeOrbsTokenStakingRewardsVars {

--- a/test/staking-rewards.spec.ts
+++ b/test/staking-rewards.spec.ts
@@ -16,7 +16,7 @@ async function sleep(ms): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe('staking-rewards-level-flows', async () => {
+describe.only('staking-rewards-level-flows', async () => {
 
   it('should distribute staking rewards to validators in general committee', async () => {
     const d = await Driver.new();
@@ -581,7 +581,7 @@ describe('staking-rewards-level-flows', async () => {
     });
   });
 
-  it('first address in distribute must be the main address of the sender', async () => {
+  it('any address in distribute can be the main address of the sender', async () => {
     const d = await Driver.new();
 
     const {v} = await d.newValidator(fromTokenUnits(1000), false, false, true);
@@ -603,7 +603,7 @@ describe('staking-rewards-level-flows', async () => {
 
     await d.rewards.assignRewards();
 
-    await expectRejected(d.rewards.distributeOrbsTokenStakingRewards(
+    await d.rewards.distributeOrbsTokenStakingRewards(
         fromTokenUnits(5),
         0,
         100,
@@ -612,27 +612,27 @@ describe('staking-rewards-level-flows', async () => {
         [delegator.address],
         [fromTokenUnits(5)],
         {from: v.address}
-    ));
-
-    await expectRejected(d.rewards.distributeOrbsTokenStakingRewards(
-        fromTokenUnits(5),
-        0,
-        100,
-        1,
-        0,
-        [v.orbsAddress],
-        [fromTokenUnits(5)],
-        {from: v.address}
-    ));
+    );
 
     await d.rewards.distributeOrbsTokenStakingRewards(
-        fromTokenUnits(5),
+        fromTokenUnits(2),
         0,
         100,
         1,
+        1,
+        [delegator.address, v.address],
+        [fromTokenUnits(1), fromTokenUnits(1)],
+        {from: v.address}
+    );
+
+    await d.rewards.distributeOrbsTokenStakingRewards(
+        fromTokenUnits(2),
         0,
-        [v.address],
-        [fromTokenUnits(5)],
+        100,
+        1,
+        2 ,
+        [v.address, delegator.address],
+        [fromTokenUnits(1), fromTokenUnits(1)],
         {from: v.address}
     );
   });
@@ -673,6 +673,17 @@ describe('staking-rewards-level-flows', async () => {
         {from: v.address}
     ));
 
+    await expectRejected(d.rewards.distributeOrbsTokenStakingRewards(
+        fromTokenUnits(2),
+        0,
+        100,
+        1,
+        0,
+        [delegator.address],
+        [fromTokenUnits(2)],
+        {from: v.address}
+    ));
+
     await d.rewards.distributeOrbsTokenStakingRewards(
         fromTokenUnits(100000),
         0,
@@ -684,7 +695,7 @@ describe('staking-rewards-level-flows', async () => {
         {from: v.address}
     );
 
-    // +1 for rounding errors should allow this
+    // +1 for rounding errors should allow these
     await d.rewards.distributeOrbsTokenStakingRewards(
         fromTokenUnits(99999),
         0,
@@ -696,13 +707,36 @@ describe('staking-rewards-level-flows', async () => {
         {from: v.address}
     );
 
-    // Distribute only to validator
     await d.rewards.distributeOrbsTokenStakingRewards(
         fromTokenUnits(1),
         0,
         100,
         1,
         2,
+        [delegator.address],
+        [fromTokenUnits(1)],
+        {from: v.address}
+    );
+
+    // validator reward can be split to multiple entries
+    await d.rewards.distributeOrbsTokenStakingRewards(
+        fromTokenUnits(5),
+        0,
+        100,
+        1,
+        3,
+        [v.address, delegator.address, v.address],
+        [fromTokenUnits(1), fromTokenUnits(2), fromTokenUnits(2)],
+        {from: v.address}
+    );
+
+    // Distribute only to validator
+    await d.rewards.distributeOrbsTokenStakingRewards(
+        fromTokenUnits(1),
+        0,
+        100,
+        1,
+        4,
         [v.address],
         [fromTokenUnits(1)],
         {from: v.address}

--- a/test/staking-rewards.spec.ts
+++ b/test/staking-rewards.spec.ts
@@ -3,7 +3,7 @@ import 'mocha';
 import BN from "bn.js";
 import {Driver, expectRejected} from "./driver";
 import chai from "chai";
-import {bn, bnSum, evmIncreaseTime, fromTokenUnits, toTokenUnits, txTimestamp} from "./helpers";
+import {bn, bnSum, evmIncreaseTime, evmMine, fromTokenUnits, toTokenUnits, txTimestamp} from "./helpers";
 
 chai.use(require('chai-bn')(BN));
 chai.use(require('./matchers'));
@@ -16,12 +16,16 @@ async function sleep(ms): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe.only('staking-rewards-level-flows', async () => {
+describe('staking-rewards', async () => {
+
+  before(async () => {
+    const d = await Driver.new();
+    await evmMine(d.web3, 200); // tests assume block 200 is in the past
+  });
 
   it('should distribute staking rewards to validators in general committee', async () => {
-    const d = await Driver.new();
-
     /* top up staking rewards pool */
+    const d = await Driver.new();
     const g = d.functionalOwner;
 
     const annualRate = bn(12000);

--- a/test/staking-rewards.spec.ts
+++ b/test/staking-rewards.spec.ts
@@ -683,6 +683,31 @@ describe('staking-rewards-level-flows', async () => {
         [fromTokenUnits(33334), fromTokenUnits(66666)],
         {from: v.address}
     );
+
+    // +1 for rounding errors should allow this
+    await d.rewards.distributeOrbsTokenStakingRewards(
+        fromTokenUnits(99999),
+        0,
+        100,
+        1,
+        1,
+        [v.address, delegator.address],
+        [fromTokenUnits(33333), fromTokenUnits(66666)],
+        {from: v.address}
+    );
+
+    // Distribute only to validator
+    await d.rewards.distributeOrbsTokenStakingRewards(
+        fromTokenUnits(1),
+        0,
+        100,
+        1,
+        2,
+        [v.address],
+        [fromTokenUnits(1)],
+        {from: v.address}
+    );
+
   });
 
 });


### PR DESCRIPTION
When check the guardion/delegator ratio in staking rewards distribution, allow for an error of up to 1 milli-orbs, to account for rounding errors.

Also, relax the distribution API such that the guardian may or may not appear in the list (instead of enforcing it to always appear first).