### PR TITLE
GUARDIAN_REGISTRATION: Initial migration by passing addresses to constructor

### DIFF
--- a/eth.ts
+++ b/eth.ts
@@ -94,7 +94,11 @@ export class Web3Driver{
             this.contracts.set(web3Contract.options.address, {web3Contract, name:contractName})
             this.log("Deployed " + contractName + " at " + web3Contract.options.address);
 
-            return new Contract(this, session, abi, web3Contract.options.address) as Contracts[N];
+            while (txHash == null) {
+                await new Promise((resolve) => setTimeout(resolve, 10));
+            }
+
+            return new Contract(this, session, abi, web3Contract.options.address, txHash) as Contracts[N];
         }
 
         throw new Error(`Failed deploying contract ${contractName} after 5 attempts`);
@@ -149,7 +153,7 @@ export class Web3Driver{
 
 export class Contract {
 
-    constructor(public web3: Web3Driver, private session: Web3Session, abi: any, public address: string) {
+    constructor(public web3: Web3Driver, private session: Web3Session, abi: any, public address: string, public txHash?: string) {
         Object.keys(this.web3Contract.methods)
             .filter(x => x[0] != '0')
             .forEach(m => {
@@ -200,5 +204,13 @@ export class Contract {
         }
 
         throw new Error(`Calling contract method "${method}" failed after 5 attempts`);
+    }
+
+    async getCreationTx(): Promise<TransactionReceipt> {
+        if (this.txHash == null) {
+            throw new Error("Unable to get tx receipt for a contract not deployed by the testkit");
+        }
+
+        return this.web3.eth.getTransactionReceipt(this.txHash);
     }
 }

--- a/test/driver.ts
+++ b/test/driver.ts
@@ -258,7 +258,7 @@ export class Driver {
         const guardiansRegistration = options.guardiansRegistrationAddress ?
             await web3.getExisting('GuardiansRegistration', options.guardiansRegistrationAddress, session)
             :
-            await web3.deploy('GuardiansRegistration', [], null, session);
+            await web3.deploy('GuardiansRegistration', [ZERO_ADDR, []], null, session);
 
         const generalFeesWallet = options.generalFeesWalletAddress ?
             await web3.getExisting('FeesWallet', options.generalFeesWalletAddress, session)

--- a/test/event-parsing.ts
+++ b/test/event-parsing.ts
@@ -27,10 +27,10 @@ export function parseLogs(txResult, contract, eventSignature, contractAddress?: 
     const abi = new Web3().eth.abi;
     const inputs = contract.abi.find(e => e.name == eventSignature.split('(')[0]).inputs;
     const eventSignatureHash = abi.encodeEventSignature(eventSignature);
-    return _.values(txResult.events)
+    return _.values(txResult.events || txResult.logs)
         .reduce((x,y) => x.concat(y), [])
         .filter(e => contractAddress == null || contractAddress == e.address)
-        .map(e => e.raw)
+        .map(e => e.raw || e)
         .filter(e => e.topics[0] === eventSignatureHash)
         .map(e => abi.decodeLog(inputs, e.data, e.topics.slice(1) /*assume all events are non-anonymous*/));
 }

--- a/test/guardian-registration.spec.ts
+++ b/test/guardian-registration.spec.ts
@@ -12,7 +12,7 @@ chai.use(require('./matchers'));
 const expect = chai.expect;
 
 // todo: test that committees are updated as a result of registration changes
-describe('guardian-registration', async () => {
+describe.only('guardian-registration', async () => {
 
   it("registers, updates and unregisters a guardian", async () => {
     const d = await Driver.new();
@@ -774,7 +774,7 @@ describe('guardian-registration', async () => {
     expect(await d.guardiansRegistration.resolveGuardianAddress(v.address)).to.deep.equal(v.address);
   });
 
-  it('is able to migrate registered guardians from a previous contract', async () => {
+  it.only('is able to migrate registered guardians from a previous contract', async () => {
     const d = await Driver.new();
 
     const v1 = d.newParticipant();
@@ -794,6 +794,24 @@ describe('guardian-registration', async () => {
     const v2LastUpdateTime = v2RegistrationTime;
 
     const newContract: GuardiansRegistrationContract = await d.web3.deploy('GuardiansRegistration', [d.guardiansRegistration.address, [v1.address, v2.address]], null, d.session);
+    const creationTx = await newContract.getCreationTx()
+    expect(creationTx).to.have.a.guardianDataUpdatedEvent({
+      addr: v1.address,
+      orbsAddr: v1.orbsAddress,
+      name: v1.name,
+      website: v1.website,
+      contact: v1.contact,
+      isRegistered: true
+    });
+    expect(creationTx).to.have.a.guardianMetadataChangedEvent({key: "REWARDS_FREQUENCY_SEC", newValue: "123", oldValue: ""});
+    expect(creationTx).to.have.a.guardianDataUpdatedEvent({
+      addr: v2.address,
+      orbsAddr: v2.orbsAddress,
+      name: v2.name,
+      website: v2.website,
+      contact: v2.contact,
+      isRegistered: true
+    });
     d.guardiansRegistration = null as any;
 
     const v1Data = await newContract.getGuardianData(v1.address);


### PR DESCRIPTION
The constructor now takes two arguments - the address of a previous `GuardianRegistration` contract, and a list of addresses to migrate.
It then reads the data into its own state, and also reads a specific metadata field for each guardian - `REWARDS_FREQUENCY_SEC`.