### PR TITLE
CONTRACT_REGISTY_ACCESSOR: Pass registry manager in constructors 

### DIFF
--- a/contracts/Certification.sol
+++ b/contracts/Certification.sol
@@ -9,7 +9,7 @@ contract Certification is ICertification, WithClaimableFunctionalOwnership, Lock
 
     mapping (address => bool) guardianCertification;
 
-    constructor(IContractRegistry _contractRegistry, address _registryOwner) Lockable(_contractRegistry, _registryOwner) public {}
+    constructor(IContractRegistry _contractRegistry, address _registryManager) Lockable(_contractRegistry, _registryManager) public {}
 
     /*
      * External methods

--- a/contracts/Certification.sol
+++ b/contracts/Certification.sol
@@ -3,8 +3,9 @@ pragma solidity 0.5.16;
 import "./spec_interfaces/ICertification.sol";
 import "./ContractRegistryAccessor.sol";
 import "./WithClaimableFunctionalOwnership.sol";
+import "./Lockable.sol";
 
-contract Certification is ICertification, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
+contract Certification is ICertification, WithClaimableFunctionalOwnership, Lockable {
 
     mapping (address => bool) guardianCertification;
 

--- a/contracts/Certification.sol
+++ b/contracts/Certification.sol
@@ -9,6 +9,8 @@ contract Certification is ICertification, WithClaimableFunctionalOwnership, Lock
 
     mapping (address => bool) guardianCertification;
 
+    constructor(IContractRegistry _contractRegistry) Lockable(_contractRegistry) public {}
+
     /*
      * External methods
      */
@@ -20,7 +22,12 @@ contract Certification is ICertification, WithClaimableFunctionalOwnership, Lock
     function setGuardianCertification(address addr, bool isCertified) external onlyFunctionalOwner onlyWhenActive {
         guardianCertification[addr] = isCertified;
         emit GuardianCertificationUpdate(addr, isCertified);
-        getElectionsContract().guardianCertificationChanged(addr, isCertified);
+        electionsContract.guardianCertificationChanged(addr, isCertified);
+    }
+
+    IElections electionsContract;
+    function refreshContracts() external {
+        electionsContract = getElectionsContract();
     }
 
 }

--- a/contracts/Certification.sol
+++ b/contracts/Certification.sol
@@ -9,7 +9,7 @@ contract Certification is ICertification, WithClaimableFunctionalOwnership, Lock
 
     mapping (address => bool) guardianCertification;
 
-    constructor(IContractRegistry _contractRegistry) Lockable(_contractRegistry) public {}
+    constructor(IContractRegistry _contractRegistry, address _registryOwner) Lockable(_contractRegistry, _registryOwner) public {}
 
     /*
      * External methods

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -6,9 +6,10 @@ import "@openzeppelin/contracts/math/Math.sol";
 import "./ContractRegistryAccessor.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 import "solidity-bytes-utils/contracts/BytesLib.sol";
+import "./Lockable.sol";
 
 /// @title Elections contract interface
-contract Committee is ICommittee, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
+contract Committee is ICommittee, WithClaimableFunctionalOwnership, Lockable {
 	using BytesLib for bytes;
 
 	uint constant MAX_COMMITTEE_ARRAY_SIZE = 32; // Cannot be greater than 32 (number of bytes in bytes32)

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -215,7 +215,7 @@ contract Committee is ICommittee, WithClaimableFunctionalOwnership, Lockable {
 		emit CommitteeSnapshot(committeeAddrs, committeeWeights, committeeCertification);
 	}
 
-	constructor(IContractRegistry _contractRegistry, uint _maxCommitteeSize, uint32 maxTimeBetweenRewardAssignments) Lockable(_contractRegistry) public {
+	constructor(IContractRegistry _contractRegistry, address _registryManager, uint _maxCommitteeSize, uint32 maxTimeBetweenRewardAssignments) Lockable(_contractRegistry, _registryManager) public {
 		require(_maxCommitteeSize > 0, "maxCommitteeSize must be larger than 0");
 		require(_maxCommitteeSize <= MAX_COMMITTEE_ARRAY_SIZE, "maxCommitteeSize must be 32 at most");
 		settings = Settings({

--- a/contracts/ContractRegistry.sol
+++ b/contracts/ContractRegistry.sol
@@ -1,20 +1,84 @@
 pragma solidity 0.5.16;
 import "./spec_interfaces/IContractRegistry.sol";
+import "./IContractRegistryListener.sol";
 import "./WithClaimableMigrationOwnership.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 
 contract ContractRegistry is IContractRegistry, WithClaimableMigrationOwnership, WithClaimableFunctionalOwnership {
 
-	mapping (string => address) contracts;
+	struct Contract {
+		address addr;
+		bool isManaged;
+	}
+	mapping (bytes32 => Contract) idToContract;
+	bytes32[] contractIds;
 
-	function set(string calldata contractName, address addr) external onlyFunctionalOwner {
-		contracts[contractName] = addr;
-		emit ContractAddressUpdated(contractName, addr);
+	function setContracts(bytes32[] calldata ids, address[] calldata addrs, bool[] calldata isManaged) external onlyFunctionalOwner {
+		require(ids.length == addrs.length, "ids, addrs array length mismatch");
+		require(ids.length == isManaged.length, "ids, isManaged array length mismatch");
+		for (uint i = 0; i < ids.length; i++) {
+			bytes32 contractId = ids[i];
+			address addr = addrs[i];
+			bool isCurrentManaged = isManaged[i];
+			if (addr != address(0)) {
+				if (idToContract[contractId].addr == address(0)) {
+					addName(contractId);
+				}
+			} else {
+				isCurrentManaged = false;
+				if (idToContract[contractId].addr != address(0)) {
+					removeName(contractId);
+				}
+			}
+			idToContract[contractId] = Contract({
+				addr: addr,
+				isManaged: isCurrentManaged
+			});
+			emit ContractAddressUpdated(contractId, addr, isCurrentManaged);
+		}
+
+		notifyOnContractsChange();
 	}
 
-	function get(string calldata contractName) external view returns (address) {
-		address addr = contracts[contractName];
-		require(addr != address(0), "the contract name is not registered");
-		return addr;
+	function notifyOnContractsChange() private {
+		bytes32[] memory _contractIds = contractIds;
+		Contract memory curContract;
+		for (uint i = 0; i < _contractIds.length; i++) {
+			curContract = idToContract[_contractIds[i]];
+			if (curContract.isManaged) {
+				IContractRegistryListener(curContract.addr).refreshContracts();
+			}
+		}
+	}
+
+	function addName(bytes32 contractId) private {
+		uint n = contractIds.length;
+		contractIds.length = n + 1;
+		contractIds[n] = contractId;
+	}
+
+	function removeName(bytes32 contractId) private {
+		uint n = contractIds.length;
+		uint i;
+		bool found;
+		for (i = 0;
+			i < n && contractId != contractIds[i];
+			i++) {}
+
+		if (!found) return;
+
+		for (; i < n - 1; i++) {
+			contractIds[i] = contractIds[i + 1];
+		}
+		contractIds.length = n - 1;
+	}
+
+	function getContracts(bytes32[] calldata ids) external view returns (address[] memory) {
+		address[] memory addrs = new address[](ids.length);
+		for (uint i = 0; i < ids.length; i++) {
+			addrs[i] = idToContract[ids[i]].addr;
+			require(addrs[i] != address(0), "the contract id is not registered");
+		}
+		return addrs;
 	}
 }

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -11,7 +11,6 @@ import "./spec_interfaces/IDelegation.sol";
 import "./spec_interfaces/IFeesWallet.sol";
 import "./interfaces/IRewards.sol";
 import "./WithClaimableMigrationOwnership.sol";
-import "./Lockable.sol";
 import "./spec_interfaces/IProtocolWallet.sol";
 
 contract ContractRegistryAccessor is WithClaimableMigrationOwnership {

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -12,68 +12,95 @@ import "./spec_interfaces/IFeesWallet.sol";
 import "./interfaces/IRewards.sol";
 import "./WithClaimableMigrationOwnership.sol";
 import "./spec_interfaces/IProtocolWallet.sol";
+import "./IContractRegistryListener.sol";
 
 contract ContractRegistryAccessor is WithClaimableMigrationOwnership {
 
     IContractRegistry contractRegistry;
 
+    constructor(IContractRegistry _contractRegistry) public {
+        require(address(_contractRegistry) != address(0), "_contractRegistry cannot be 0");
+        setContractRegistry(_contractRegistry);
+    }
+
     event ContractRegistryAddressUpdated(address addr);
 
-    function setContractRegistry(IContractRegistry _contractRegistry) external onlyMigrationOwner {
+    function setContractRegistry(IContractRegistry _contractRegistry) public onlyMigrationOwner {
         contractRegistry = _contractRegistry;
         emit ContractRegistryAddressUpdated(address(_contractRegistry));
     }
 
     function getProtocolContract() public view returns (IProtocol) {
-        return IProtocol(contractRegistry.get("protocol"));
+        return IProtocol(getContract("protocol"));
     }
 
     function getRewardsContract() public view returns (IRewards) {
-        return IRewards(contractRegistry.get("rewards"));
+        return IRewards(getContract("rewards"));
     }
 
     function getCommitteeContract() public view returns (ICommittee) {
-        return ICommittee(contractRegistry.get("committee"));
+        return ICommittee(getContract("committee"));
     }
 
     function getElectionsContract() public view returns (IElections) {
-        return IElections(contractRegistry.get("elections"));
+        return IElections(getContract("elections"));
     }
 
     function getDelegationsContract() public view returns (IDelegations) {
-        return IDelegations(contractRegistry.get("delegations"));
+        return IDelegations(getContract("delegations"));
     }
 
     function getGuardiansRegistrationContract() public view returns (IGuardiansRegistration) {
-        return IGuardiansRegistration(contractRegistry.get("guardiansRegistration"));
+        return IGuardiansRegistration(getContract("guardiansRegistration"));
     }
 
     function getCertificationContract() public view returns (ICertification) {
-        return ICertification(contractRegistry.get("certification"));
+        return ICertification(getContract("certification"));
     }
 
     function getStakingContract() public view returns (IStakingContract) {
-        return IStakingContract(contractRegistry.get("staking"));
+        return IStakingContract(getContract("staking"));
     }
 
     function getSubscriptionsContract() public view returns (ISubscriptions) {
-        return ISubscriptions(contractRegistry.get("subscriptions"));
+        return ISubscriptions(getContract("subscriptions"));
     }
 
     function getStakingRewardsWallet() public view returns (IProtocolWallet) {
-        return IProtocolWallet(contractRegistry.get("stakingRewardsWallet"));
+        return IProtocolWallet(getContract("stakingRewardsWallet"));
     }
 
     function getBootstrapRewardsWallet() public view returns (IProtocolWallet) {
-        return IProtocolWallet(contractRegistry.get("bootstrapRewardsWallet"));
+        return IProtocolWallet(getContract("bootstrapRewardsWallet"));
     }
 
     function getGeneralFeesWallet() public view returns (IFeesWallet) {
-        return IFeesWallet(contractRegistry.get("generalFeesWallet"));
+        return IFeesWallet(getContract("generalFeesWallet"));
     }
 
     function getCertifiedFeesWallet() public view returns (IFeesWallet) {
-        return IFeesWallet(contractRegistry.get("certifiedFeesWallet"));
+        return IFeesWallet(getContract("certifiedFeesWallet"));
     }
 
+    function stringToBytes32(string memory source) public pure returns (bytes32 result) {
+        bytes memory stringAsBytes = bytes(source);
+        if (stringAsBytes.length == 0) {
+            return 0x0;
+        }
+
+        if (stringAsBytes.length > 32) {
+            return keccak256(stringAsBytes);
+        }
+
+        assembly {
+            result := mload(add(source, 32))
+        }
+    }
+
+    function getContract(string memory name) private view returns (address) {
+        bytes32[] memory arr = new bytes32[](1);
+        arr[0] = stringToBytes32(name);
+        address[] memory addrs = contractRegistry.getContracts(arr);
+        return addrs[0];
+    }
 }

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -18,9 +18,11 @@ contract ContractRegistryAccessor is WithClaimableMigrationOwnership {
 
     IContractRegistry contractRegistry;
 
-    constructor(IContractRegistry _contractRegistry) public {
+    constructor(IContractRegistry _contractRegistry, address _registryManager) public {
         require(address(_contractRegistry) != address(0), "_contractRegistry cannot be 0");
+        require(address(_registryManager) != address(0), "_regsitryManage cannot be 0");
         setContractRegistry(_contractRegistry);
+        _transferMigrationOwnership(_registryManager);
     }
 
     event ContractRegistryAddressUpdated(address addr);

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -19,7 +19,6 @@ contract ContractRegistryAccessor is WithClaimableMigrationOwnership {
 
     constructor(IContractRegistry _contractRegistry, address _registryManager) public {
         require(address(_contractRegistry) != address(0), "_contractRegistry cannot be 0");
-        require(address(_registryManager) != address(0), "_regsitryManage cannot be 0");
         setContractRegistry(_contractRegistry);
         _transferMigrationOwnership(_registryManager);
     }

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -13,8 +13,9 @@ import "./ContractRegistryAccessor.sol";
 import "./spec_interfaces/IDelegation.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 import "./IStakeChangeNotifier.sol";
+import "./Lockable.sol";
 
-contract Delegations is IDelegations, IStakeChangeNotifier, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
+contract Delegations is IDelegations, IStakeChangeNotifier, WithClaimableFunctionalOwnership, Lockable {
 	using SafeMath for uint256;
 	using SafeMath for uint96;
 

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -35,7 +35,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, WithClaimableFunctio
 		_;
 	}
 
-	constructor(IContractRegistry _contractRegistry, address _registryOwner) Lockable(_contractRegistry, _registryOwner) public {}
+	constructor(IContractRegistry _contractRegistry, address _registryManager) Lockable(_contractRegistry, _registryManager) public {}
 
 	function getTotalDelegatedStake() external view returns (uint256) {
 		return totalDelegatedStake;

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -35,7 +35,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, WithClaimableFunctio
 		_;
 	}
 
-	constructor(IContractRegistry _contractRegistry) Lockable(_contractRegistry) public {}
+	constructor(IContractRegistry _contractRegistry, address _registryOwner) Lockable(_contractRegistry, _registryOwner) public {}
 
 	function getTotalDelegatedStake() external view returns (uint256) {
 		return totalDelegatedStake;

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -44,7 +44,7 @@ contract Elections is IElections, WithClaimableFunctionalOwnership, Lockable {
 		_;
 	}
 
-	constructor(IContractRegistry _contractRegistry, uint32 minSelfStakePercentMille, uint8 voteUnreadyPercentageThreshold, uint32 voteUnreadyTimeoutSeconds, uint8 voteOutPercentageThreshold) Lockable(_contractRegistry) public {
+	constructor(IContractRegistry _contractRegistry, address _registryManager, uint32 minSelfStakePercentMille, uint8 voteUnreadyPercentageThreshold, uint32 voteUnreadyTimeoutSeconds, uint8 voteOutPercentageThreshold) Lockable(_contractRegistry, _registryManager) public {
 		require(minSelfStakePercentMille <= 100000, "minSelfStakePercentMille must be at most 100000");
 		require(voteUnreadyPercentageThreshold >= 0 && voteUnreadyPercentageThreshold <= 100, "voteUnreadyPercentageThreshold must be between 0 and 100");
 		require(voteOutPercentageThreshold >= 0 && voteOutPercentageThreshold <= 100, "voteOutPercentageThreshold must be between 0 and 100");

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -12,9 +12,10 @@ import "./spec_interfaces/ICommittee.sol";
 import "./spec_interfaces/ICertification.sol";
 import "./ContractRegistryAccessor.sol";
 import "./WithClaimableFunctionalOwnership.sol";
+import "./Lockable.sol";
 
 
-contract Elections is IElections, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
+contract Elections is IElections, WithClaimableFunctionalOwnership, Lockable {
 	using SafeMath for uint256;
 
 	mapping (address => mapping (address => uint256)) votedUnreadyVotes; // by => to => timestamp

--- a/contracts/FeesWallet.sol
+++ b/contracts/FeesWallet.sol
@@ -12,7 +12,7 @@ import "./spec_interfaces/IFeesWallet.sol";
 
 
 /// @title Fees Wallet contract interface, manages the fee buckets
-contract FeesWallet is IFeesWallet, ContractRegistryAccessor, WithClaimableFunctionalOwnership {
+contract FeesWallet is IFeesWallet, ContractRegistryAccessor {
     using SafeMath for uint256;
 
     event FeesWithdrawnFromBucket(uint256 bucketId, uint256 withdrawn, uint256 total);

--- a/contracts/FeesWallet.sol
+++ b/contracts/FeesWallet.sol
@@ -32,7 +32,7 @@ contract FeesWallet is IFeesWallet, ContractRegistryAccessor {
         _;
     }
 
-    constructor(IContractRegistry _contractRegistry, IERC20 _token) ContractRegistryAccessor(_contractRegistry) public {
+    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _token) ContractRegistryAccessor(_contractRegistry, _registryManager) public {
         token = _token;
         lastCollectedAt = now;
     }

--- a/contracts/FeesWallet.sol
+++ b/contracts/FeesWallet.sol
@@ -27,12 +27,12 @@ contract FeesWallet is IFeesWallet, ContractRegistryAccessor {
     uint256 lastCollectedAt;
 
     modifier onlyRewardsContract() {
-        require(msg.sender == address(getRewardsContract()), "caller is not the rewards contract");
+        require(msg.sender == address(rewardsContract), "caller is not the rewards contract");
 
         _;
     }
 
-    constructor(IERC20 _token) public {
+    constructor(IContractRegistry _contractRegistry, IERC20 _token) ContractRegistryAccessor(_contractRegistry) public {
         token = _token;
         lastCollectedAt = now;
     }
@@ -150,6 +150,11 @@ contract FeesWallet is IFeesWallet, ContractRegistryAccessor {
 
     function _bucketTime(uint256 time) private pure returns (uint256) {
         return time - time % BUCKET_TIME_PERIOD;
+    }
+
+    IRewards rewardsContract;
+    function refreshContracts() external {
+        rewardsContract = getRewardsContract();
     }
 
 }

--- a/contracts/GuardiansRegistration.sol
+++ b/contracts/GuardiansRegistration.sol
@@ -28,6 +28,8 @@ contract GuardiansRegistration is IGuardiansRegistration, WithClaimableFunctiona
 	mapping (bytes4 => address) public ipToGuardian;
 	mapping (address => mapping(string => string)) public guardianMetadata;
 
+	constructor(IContractRegistry _contractRegistry) Lockable(_contractRegistry) public {}
+
 	/*
      * External methods
      */
@@ -41,7 +43,7 @@ contract GuardiansRegistration is IGuardiansRegistration, WithClaimableFunctiona
 
 		_updateGuardian(msg.sender, ip, orbsAddr, name, website, contact);
 
-		getElectionsContract().guardianRegistered(msg.sender);
+		electionsContract.guardianRegistered(msg.sender);
 	}
 
     /// @dev Called by a participant who wishes to update its properties
@@ -74,7 +76,7 @@ contract GuardiansRegistration is IGuardiansRegistration, WithClaimableFunctiona
 		Guardian memory guardian = guardians[msg.sender];
 		delete guardians[msg.sender];
 
-		getElectionsContract().guardianUnregistered(msg.sender);
+		electionsContract.guardianUnregistered(msg.sender);
 		emit GuardianDataUpdated(msg.sender, false, guardian.ip, guardian.orbsAddr, guardian.name, guardian.website, guardian.contact);
 		emit GuardianUnregistered(msg.sender);
 	}
@@ -168,5 +170,10 @@ contract GuardiansRegistration is IGuardiansRegistration, WithClaimableFunctiona
 
         emit GuardianDataUpdated(guardianAddr, true, ip, orbsAddr, name, website, contact);
     }
+
+	IElections electionsContract;
+	function refreshContracts() external {
+		electionsContract = getElectionsContract();
+	}
 
 }

--- a/contracts/GuardiansRegistration.sol
+++ b/contracts/GuardiansRegistration.sol
@@ -4,8 +4,9 @@ import "./spec_interfaces/IGuardiansRegistration.sol";
 import "./interfaces/IElections.sol";
 import "./ContractRegistryAccessor.sol";
 import "./WithClaimableFunctionalOwnership.sol";
+import "./Lockable.sol";
 
-contract GuardiansRegistration is IGuardiansRegistration, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
+contract GuardiansRegistration is IGuardiansRegistration, WithClaimableFunctionalOwnership, Lockable {
 
 	modifier onlyRegisteredGuardian {
 		require(isRegistered(msg.sender), "Guardian is not registered");

--- a/contracts/GuardiansRegistration.sol
+++ b/contracts/GuardiansRegistration.sol
@@ -28,7 +28,7 @@ contract GuardiansRegistration is IGuardiansRegistration, WithClaimableFunctiona
 	mapping (bytes4 => address) public ipToGuardian;
 	mapping (address => mapping(string => string)) public guardianMetadata;
 
-	constructor(IContractRegistry _contractRegistry, address _registryOwner) Lockable(_contractRegistry, _registryOwner) public {}
+	constructor(IContractRegistry _contractRegistry, address _registryManager) Lockable(_contractRegistry, _registryManager) public {}
 
 	/*
      * External methods

--- a/contracts/GuardiansRegistration.sol
+++ b/contracts/GuardiansRegistration.sol
@@ -28,7 +28,7 @@ contract GuardiansRegistration is IGuardiansRegistration, WithClaimableFunctiona
 	mapping (bytes4 => address) public ipToGuardian;
 	mapping (address => mapping(string => string)) public guardianMetadata;
 
-	constructor(IContractRegistry _contractRegistry) Lockable(_contractRegistry) public {}
+	constructor(IContractRegistry _contractRegistry, address _registryOwner) Lockable(_contractRegistry, _registryOwner) public {}
 
 	/*
      * External methods

--- a/contracts/IContractRegistryListener.sol
+++ b/contracts/IContractRegistryListener.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.5.16;
+
+interface IContractRegistryListener {
+
+    function refreshContracts() external;
+
+}

--- a/contracts/Lockable.sol
+++ b/contracts/Lockable.sol
@@ -1,26 +1,26 @@
 pragma solidity 0.5.16;
 
-import "./WithClaimableMigrationOwnership.sol";
+import "./ContractRegistryAccessor.sol";
 
-
-/**
- * @title Claimable
- * @dev Extension for the Ownable contract, where the ownership needs to be claimed.
- * This allows the new owner to accept the transfer.
- */
-contract Lockable is WithClaimableMigrationOwnership {
+contract Lockable is ContractRegistryAccessor {
 
     bool public locked;
 
     event Locked();
     event Unlocked();
 
-    function lock() external onlyMigrationOwner {
+    modifier onlyLockOwner() {
+        require(msg.sender == migrationOwner() || msg.sender == address(contractRegistry), "caller is not a lock owner");
+
+        _;
+    }
+
+    function lock() external onlyLockOwner {
         locked = true;
         emit Locked();
     }
 
-    function unlock() external onlyMigrationOwner {
+    function unlock() external onlyLockOwner {
         locked = false;
         emit Unlocked();
     }

--- a/contracts/Lockable.sol
+++ b/contracts/Lockable.sol
@@ -15,7 +15,7 @@ contract Lockable is ContractRegistryAccessor {
         _;
     }
 
-    constructor(IContractRegistry _contractRegistry) ContractRegistryAccessor(_contractRegistry) public {}
+    constructor(IContractRegistry _contractRegistry, address _registryManager) ContractRegistryAccessor(_contractRegistry, _registryManager) public {}
 
     function lock() external onlyLockOwner {
         locked = true;

--- a/contracts/Lockable.sol
+++ b/contracts/Lockable.sol
@@ -15,6 +15,8 @@ contract Lockable is ContractRegistryAccessor {
         _;
     }
 
+    constructor(IContractRegistry _contractRegistry) ContractRegistryAccessor(_contractRegistry) public {}
+
     function lock() external onlyLockOwner {
         locked = true;
         emit Locked();

--- a/contracts/MonthlySubscriptionPlan.sol
+++ b/contracts/MonthlySubscriptionPlan.sol
@@ -13,7 +13,7 @@ contract MonthlySubscriptionPlan is ContractRegistryAccessor, WithClaimableFunct
 
     IERC20 erc20;
 
-    constructor(IERC20 _erc20, string memory _tier, uint256 _monthlyRate) public {
+    constructor(IContractRegistry _contractRegistry, IERC20 _erc20, string memory _tier, uint256 _monthlyRate) ContractRegistryAccessor(_contractRegistry) public {
         require(bytes(_tier).length > 0, "must specify a valid tier label");
 
         tier = _tier;
@@ -25,7 +25,6 @@ contract MonthlySubscriptionPlan is ContractRegistryAccessor, WithClaimableFunct
         require(amount > 0, "must include funds");
 
         ISubscriptions subs = getSubscriptionsContract();
-
         require(erc20.transferFrom(msg.sender, address(this), amount), "failed to transfer subscription fees");
         require(erc20.approve(address(subs), amount), "failed to transfer subscription fees");
         subs.createVC(name, tier, monthlyRate, amount, msg.sender, isCertified, deploymentSubset);
@@ -40,4 +39,10 @@ contract MonthlySubscriptionPlan is ContractRegistryAccessor, WithClaimableFunct
         require(erc20.approve(address(subs), amount), "failed to approve subscription fees to subscriptions by subscriber");
         subs.extendSubscription(vcid, amount, msg.sender);
     }
+
+//    ISubscriptions subscriptionsContract;
+//    function refreshContracts() external {
+//        subscriptionsContract = getSubscriptionsContract();
+//    }
+
 }

--- a/contracts/MonthlySubscriptionPlan.sol
+++ b/contracts/MonthlySubscriptionPlan.sol
@@ -13,7 +13,7 @@ contract MonthlySubscriptionPlan is ContractRegistryAccessor, WithClaimableFunct
 
     IERC20 erc20;
 
-    constructor(IContractRegistry _contractRegistry, IERC20 _erc20, string memory _tier, uint256 _monthlyRate) ContractRegistryAccessor(_contractRegistry) public {
+    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _erc20, string memory _tier, uint256 _monthlyRate) ContractRegistryAccessor(_contractRegistry, _registryManager) public {
         require(bytes(_tier).length > 0, "must specify a valid tier label");
 
         tier = _tier;

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -17,7 +17,7 @@ contract Protocol is IProtocol, WithClaimableFunctionalOwnership, Lockable {
 
     mapping (string => DeploymentSubset) deploymentSubsets;
 
-    constructor(IContractRegistry _contractRegistry) Lockable(_contractRegistry) public {}
+    constructor(IContractRegistry _contractRegistry, address _registryManager) Lockable(_contractRegistry, _registryManager) public {}
 
     function deploymentSubsetExists(string calldata deploymentSubset) external view returns (bool) {
         return deploymentSubsets[deploymentSubset].exists;

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -4,8 +4,9 @@ import "./spec_interfaces/IProtocol.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 import "./WithClaimableMigrationOwnership.sol";
 import "./ContractRegistryAccessor.sol";
+import "./Lockable.sol";
 
-contract Protocol is IProtocol, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
+contract Protocol is IProtocol, WithClaimableFunctionalOwnership, Lockable {
 
     struct DeploymentSubset {
         bool exists;

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -17,6 +17,8 @@ contract Protocol is IProtocol, WithClaimableFunctionalOwnership, Lockable {
 
     mapping (string => DeploymentSubset) deploymentSubsets;
 
+    constructor(IContractRegistry _contractRegistry) Lockable(_contractRegistry) public {}
+
     function deploymentSubsetExists(string calldata deploymentSubset) external view returns (bool) {
         return deploymentSubsets[deploymentSubset].exists;
     }
@@ -58,4 +60,6 @@ contract Protocol is IProtocol, WithClaimableFunctionalOwnership, Lockable {
         currentVersion = prevUpgradeExecuted ? deploymentSubsets[deploymentSubset].nextVersion :
                                                deploymentSubsets[deploymentSubset].currentVersion;
     }
+
+    function refreshContracts() external {}
 }

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -44,7 +44,7 @@ contract Rewards is IRewards, ERC20AccessorWithTokenGranularity, WithClaimableFu
         _;
     }
 
-    constructor(IContractRegistry _contractRegistry, IERC20 _erc20, IERC20 _bootstrapToken) Lockable(_contractRegistry) public {
+    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _erc20, IERC20 _bootstrapToken) Lockable(_contractRegistry, _registryManager) public {
         require(address(_bootstrapToken) != address(0), "bootstrapToken must not be 0");
         require(address(_erc20) != address(0), "erc20 must not be 0");
 

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -11,8 +11,9 @@ import "./ContractRegistryAccessor.sol";
 import "./Erc20AccessorWithTokenGranularity.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 import "./spec_interfaces/IFeesWallet.sol";
+import "./Lockable.sol";
 
-contract Rewards is IRewards, ContractRegistryAccessor, ERC20AccessorWithTokenGranularity, WithClaimableFunctionalOwnership, Lockable {
+contract Rewards is IRewards, ERC20AccessorWithTokenGranularity, WithClaimableFunctionalOwnership, Lockable {
     using SafeMath for uint256;
     using SafeMath for uint48;
 

--- a/contracts/StakingContractHandler.sol
+++ b/contracts/StakingContractHandler.sol
@@ -7,7 +7,7 @@ contract StakingContractHandler is IStakingContractHandler, IStakeChangeNotifier
 
     uint constant NOTIFICATION_GAS_LIMIT = 5000000;
 
-    constructor(IContractRegistry _contractRegistry) public ContractRegistryAccessor(_contractRegistry) {}
+    constructor(IContractRegistry _contractRegistry, address _registryManager) public ContractRegistryAccessor(_contractRegistry, _registryManager) {}
 
     modifier onlyStakingContract() {
         require(msg.sender == address(getStakingContract()), "caller is not the staking contract");

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -38,7 +38,7 @@ contract Subscriptions is ISubscriptions, WithClaimableFunctionalOwnership, Lock
 
     IERC20 public erc20;
 
-    constructor (IContractRegistry _contractRegistry, IERC20 _erc20) Lockable(_contractRegistry) public {
+    constructor (IContractRegistry _contractRegistry, address _registryManager, IERC20 _erc20) Lockable(_contractRegistry, _registryManager) public {
         require(address(_erc20) != address(0), "erc20 must not be 0");
 
         nextVcid = 1000000;

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -6,8 +6,9 @@ import "./spec_interfaces/IProtocol.sol";
 import "./ContractRegistryAccessor.sol";
 import "./WithClaimableFunctionalOwnership.sol";
 import "./spec_interfaces/IFeesWallet.sol";
+import "./Lockable.sol";
 
-contract Subscriptions is ISubscriptions, ContractRegistryAccessor, WithClaimableFunctionalOwnership, Lockable {
+contract Subscriptions is ISubscriptions, WithClaimableFunctionalOwnership, Lockable {
     using SafeMath for uint256;
 
     enum CommitteeType {

--- a/contracts/spec_interfaces/IContractRegistry.sol
+++ b/contracts/spec_interfaces/IContractRegistry.sol
@@ -2,11 +2,12 @@ pragma solidity 0.5.16;
 
 interface IContractRegistry {
 
-	event ContractAddressUpdated(string contractName, address addr);
+	event ContractAddressUpdated(bytes32 contractId, address addr, bool isManaged);
 
 	/// @dev updates the contracts address and emits a corresponding event
-	function set(string calldata contractName, address addr) external /* onlyGovernor */;
+	function setContracts(bytes32[] calldata contractIds, address[] calldata addrs, bool[] calldata isManaged) external /* onlyFunctionalOwner */;
 
-	/// @dev returns the current address of the
-	function get(string calldata contractName) external view returns (address);
+	/// @dev returns the current address of the given contracts
+	function getContracts(bytes32[] calldata contractIds) external view returns (address[] memory);
+
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/orbs-network/orbs-ethereum-contracts-v2",
   "scripts": {
     "deploy-beta": "npm run prepublish && node --require ./tsinit.js ./deploy-beta.ts",
-    "test": "export GANACHE_CORE=true && npm run prepublish && mocha --exit --full-trace -r ./tsinit.js --exclude ./test/gas-scenarios.spec.ts ./test/*.spec.ts --timeout 1200000000",
+    "test": "export GANACHE_CORE=true && npm run prepublish && mocha --exit --bail --full-trace -r ./tsinit.js --exclude ./test/gas-scenarios.spec.ts ./test/*.spec.ts --timeout 1200000000",
     "test-ropsten": "export ETHEREUM_URL=https://ropsten.infura.io/v3/62f4815d28674debbe4703c5eb9d413c && export WEB3_DRIVER_VERBOSE=true && npm run prepublish && mocha --bail --exit --full-trace -r ./tsinit.js --exclude ./test/gas-scenarios.spec.ts ./test/*.spec.ts --timeout 1200000000",
     "test-kovan": "export ETHEREUM_URL=https://kovan.infura.io/v3/62f4815d28674debbe4703c5eb9d413c && export WEB3_DRIVER_VERBOSE=true && npm run prepublish && mocha --bail --exit --full-trace -r ./tsinit.js --exclude ./test/gas-scenarios.spec.ts ./test/*.spec.ts --timeout 1200000000",
     "test-gas-scenarios": "npm run prepublish && mocha --exit --full-trace -r ./tsinit.js ./test/gas-scenarios.spec.ts --timeout 600000",

--- a/test/committee.spec.ts
+++ b/test/committee.spec.ts
@@ -407,9 +407,9 @@ describe('committee', async () => {
     it("validate constructor arguments (0 < maxCommitteeSize <= 32)", async () => {
         const d = await Driver.new();
 
-        await expectRejected(d.web3.deploy('Committee', [d.contractRegistry.address, 0, 1]), /maxCommitteeSize must be larger than 0/);
-        await expectRejected(d.web3.deploy('Committee', [d.contractRegistry.address, 33, 1]), /maxCommitteeSize must be 32 at most/);
-        await d.web3.deploy('Committee', [d.contractRegistry.address, 1, 1]);
+        await expectRejected(d.web3.deploy('Committee', [d.contractRegistry.address, d.migrationOwner.address, 0, 1]), /maxCommitteeSize must be larger than 0/);
+        await expectRejected(d.web3.deploy('Committee', [d.contractRegistry.address, d.migrationOwner.address, 33, 1]), /maxCommitteeSize must be 32 at most/);
+        await d.web3.deploy('Committee', [d.contractRegistry.address, d.migrationOwner.address, 1, 1]);
     });
 
     it("validates weight is within range - less than 2^96", async () => {

--- a/test/contract-registry.spec.ts
+++ b/test/contract-registry.spec.ts
@@ -3,7 +3,7 @@ import 'mocha';
 import BN from "bn.js";
 import {Driver, ZERO_ADDR} from "./driver";
 import chai from "chai";
-import {expectRejected} from "./helpers";
+import {contractId, expectRejected} from "./helpers";
 
 chai.use(require('chai-bn')(BN));
 chai.use(require('./matchers'));
@@ -21,45 +21,45 @@ describe('contract-registry-high-level-flows', async () => {
     const addr1 = d.newParticipant().address;
 
     // set
-    let r = await registry.set(contract1Name, addr1, {from: owner.address});
+    let r = await registry.setContracts([contractId(contract1Name)], [addr1], [false], {from: owner.address});
     expect(r).to.have.a.contractAddressUpdatedEvent({
-      contractName: contract1Name,
+      contractId: contractId(contract1Name),
       addr: addr1
     });
 
     // get
-    expect(await registry.get(contract1Name)).to.equal(addr1);
+    expect((await registry.getContracts([contractId(contract1Name)]))[0]).to.equal(addr1);
 
     // update
     const addr2 = d.newParticipant().address;
-    r = await registry.set(contract1Name, addr2, {from: owner.address});
+    r = await registry.setContracts([contractId(contract1Name)], [addr2], [false], {from: owner.address});
     expect(r).to.have.a.contractAddressUpdatedEvent({
-      contractName: contract1Name,
+      contractId: contractId(contract1Name),
       addr: addr2
     });
 
     // get the updated address
-    expect(await registry.get(contract1Name)).to.equal(addr2);
+    expect((await registry.getContracts([contractId(contract1Name)]))[0]).to.equal(addr2);
 
     // set another by non governor
     const nonGovernor = d.newParticipant();
     const contract2Name = "committee";
     const addr3 = d.newParticipant().address;
-    await expectRejected(registry.set(contract2Name, addr3, {from: nonGovernor.address}), /caller is not the functionalOwner/);
+    await expectRejected(registry.setContracts([contractId(contract2Name)], [addr3], [false], {from: nonGovernor.address}), /caller is not the functionalOwner/);
 
     // now by governor
-    r = await registry.set(contract2Name, addr3, {from: owner.address});
+    r = await registry.setContracts([contractId(contract2Name)], [addr3], [false], {from: owner.address});
     expect(r).to.have.a.contractAddressUpdatedEvent({
-      contractName: contract2Name,
+      contractId: contractId(contract2Name),
       addr: addr3
     });
-    expect(await registry.get(contract2Name)).to.equal(addr3);
+    expect((await registry.getContracts([contractId(contract2Name)]))[0]).to.equal(addr3);
 
   });
 
   it('reverts when getting a non existent entry', async () => {
     const d = await Driver.new();
-    await expectRejected(d.contractRegistry.get("nonexistent" as any), /the contract name is not registered/);
+    await expectRejected(d.contractRegistry.getContracts([contractId("nonexistent") as any]), /the contract id is not registered/);
   });
 
   it('allows only the contract owner to update the address of the contract registry', async () => { // TODO - consider splitting and moving this

--- a/test/delegations.spec.ts
+++ b/test/delegations.spec.ts
@@ -253,7 +253,7 @@ describe('delegations-contract', async () => {
     it('uses absolute stake on first notification of stake change (batched and non-batched)', async () => {
        const d = await Driver.new();
 
-       const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address], null, d.session);
+       const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address, d.migrationOwner.address], null, d.session);
        await otherDelegationContract.setContractRegistry(d.contractRegistry.address);
 
        await d.staking.setStakeChangeNotifier(otherDelegationContract.address);
@@ -307,7 +307,7 @@ describe('delegations-contract', async () => {
     it('imports a delegation for a delegator with an existing stake (no election notification)', async () => {
        const d = await Driver.new();
 
-       const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address], null, d.session);
+       const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address, d.migrationOwner.address], null, d.session);
        await otherDelegationContract.setContractRegistry(d.contractRegistry.address);
 
        await d.staking.setStakeChangeNotifier(otherDelegationContract.address);
@@ -370,7 +370,7 @@ describe('delegations-contract', async () => {
     it('imports a delegation for a delegator with an existing stake (with election notification)', async () => {
        const d = await Driver.new();
 
-       const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address], null, d.session);
+       const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address, d.migrationOwner.address], null, d.session);
        await otherDelegationContract.setContractRegistry(d.contractRegistry.address);
 
        await d.staking.setStakeChangeNotifier(otherDelegationContract.address);
@@ -452,7 +452,7 @@ describe('delegations-contract', async () => {
         const {v} = await d.newGuardian(100, false, false, true);
         await d1.delegate(v);
 
-        const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address], null, d.session);
+        const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address, d.migrationOwner.address], null, d.session);
         await otherDelegationContract.setContractRegistry(d.contractRegistry.address);
 
         await d.staking.setStakeChangeNotifier(otherDelegationContract.address);
@@ -489,7 +489,7 @@ describe('delegations-contract', async () => {
             delegatedStake: bn(100)
         });
 
-        const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address], null, d.session);
+        const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address, d.migrationOwner.address], null, d.session);
         await otherDelegationContract.setContractRegistry(d.contractRegistry.address);
 
         await d.staking.setStakeChangeNotifier(otherDelegationContract.address);

--- a/test/delegations.spec.ts
+++ b/test/delegations.spec.ts
@@ -11,7 +11,7 @@ chai.use(require('./matchers'));
 const expect = chai.expect;
 const assert = chai.assert;
 
-import {bn, expectRejected} from "./helpers";
+import {bn, contractId, expectRejected} from "./helpers";
 import {TransactionReceipt} from "web3-core";
 
 describe('delegations-contract', async () => {
@@ -25,7 +25,7 @@ describe('delegations-contract', async () => {
 
         await expectRejected(participant.stake(5, rogueStakingContract), /caller is not the staking contract/);
         await participant.stake(5);
-        await d.contractRegistry.set("staking", rogueStakingContract.address, {from: d.functionalOwner.address});
+        await d.contractRegistry.setContracts([contractId("staking")], [rogueStakingContract.address], [false], {from: d.functionalOwner.address});
         await participant.stake(5, rogueStakingContract)
 
         // TODO - to check stakeChangeBatch use a mock staking contract that would satisfy the interface but would allow sending stakeChangeBatch when there are no rewards to distribue
@@ -253,11 +253,11 @@ describe('delegations-contract', async () => {
     it('uses absolute stake on first notification of stake change (batched and non-batched)', async () => {
        const d = await Driver.new();
 
-       const otherDelegationContract = await d.web3.deploy("Delegations", [], null, d.session);
+       const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address], null, d.session);
        await otherDelegationContract.setContractRegistry(d.contractRegistry.address);
 
        await d.staking.setStakeChangeNotifier(otherDelegationContract.address);
-       await d.contractRegistry.set("delegations", otherDelegationContract.address, {from: d.functionalOwner.address});
+       await d.contractRegistry.setContracts([contractId("delegations")], [otherDelegationContract.address], [true], {from: d.functionalOwner.address});
 
        const v1 = d.newParticipant();
        await v1.stake(100);
@@ -266,7 +266,7 @@ describe('delegations-contract', async () => {
        await v2.stake(100);
 
         await d.staking.setStakeChangeNotifier(d.delegations.address);
-        await d.contractRegistry.set("delegations", d.delegations.address, {from: d.functionalOwner.address});
+        await d.contractRegistry.setContracts([contractId("delegations")], [d.delegations.address], [true], {from: d.functionalOwner.address});
 
        // Non-batched
 
@@ -307,11 +307,11 @@ describe('delegations-contract', async () => {
     it('imports a delegation for a delegator with an existing stake (no election notification)', async () => {
        const d = await Driver.new();
 
-       const otherDelegationContract = await d.web3.deploy("Delegations", [], null, d.session);
+       const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address], null, d.session);
        await otherDelegationContract.setContractRegistry(d.contractRegistry.address);
 
        await d.staking.setStakeChangeNotifier(otherDelegationContract.address);
-       await d.contractRegistry.set("delegations", otherDelegationContract.address, {from: d.functionalOwner.address});
+       await d.contractRegistry.setContracts([contractId("delegations")], [otherDelegationContract.address], [true], {from: d.functionalOwner.address});
 
        const d1 = d.newParticipant();
        await d1.stake(100);
@@ -320,7 +320,7 @@ describe('delegations-contract', async () => {
        await d2.stake(200);
 
        await d.staking.setStakeChangeNotifier(d.delegations.address);
-       await d.contractRegistry.set("delegations", d.delegations.address, {from: d.functionalOwner.address});
+       await d.contractRegistry.setContracts([contractId("delegations")], [d.delegations.address], [true], {from: d.functionalOwner.address});
 
         const {v: v1} = await d.newGuardian(100, false, false, true);
         const {v: v2} = await d.newGuardian(100, false, false, true);
@@ -370,11 +370,11 @@ describe('delegations-contract', async () => {
     it('imports a delegation for a delegator with an existing stake (with election notification)', async () => {
        const d = await Driver.new();
 
-       const otherDelegationContract = await d.web3.deploy("Delegations", [], null, d.session);
+       const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address], null, d.session);
        await otherDelegationContract.setContractRegistry(d.contractRegistry.address);
 
        await d.staking.setStakeChangeNotifier(otherDelegationContract.address);
-       await d.contractRegistry.set("delegations", otherDelegationContract.address, {from: d.functionalOwner.address});
+       await d.contractRegistry.setContracts([contractId("delegations")], [otherDelegationContract.address], [true], {from: d.functionalOwner.address});
 
        const d1 = d.newParticipant();
        await d1.stake(100);
@@ -383,7 +383,7 @@ describe('delegations-contract', async () => {
        await d2.stake(200);
 
        await d.staking.setStakeChangeNotifier(d.delegations.address);
-       await d.contractRegistry.set("delegations", d.delegations.address, {from: d.functionalOwner.address});
+       await d.contractRegistry.setContracts([contractId("delegations")], [d.delegations.address], [true], {from: d.functionalOwner.address});
 
        const {v: v1} = await d.newGuardian(100, false, false, true);
        const {v: v2} = await d.newGuardian(100, false, false, true);
@@ -452,16 +452,16 @@ describe('delegations-contract', async () => {
         const {v} = await d.newGuardian(100, false, false, true);
         await d1.delegate(v);
 
-        const otherDelegationContract = await d.web3.deploy("Delegations", [], null, d.session);
+        const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address], null, d.session);
         await otherDelegationContract.setContractRegistry(d.contractRegistry.address);
 
         await d.staking.setStakeChangeNotifier(otherDelegationContract.address);
-        await d.contractRegistry.set("delegations", otherDelegationContract.address, {from: d.functionalOwner.address});
+        await d.contractRegistry.setContracts([contractId("delegations")], [otherDelegationContract.address], [true], {from: d.functionalOwner.address});
 
         await d1.stake(100);
 
         await d.staking.setStakeChangeNotifier(d.delegations.address);
-        await d.contractRegistry.set("delegations", d.delegations.address, {from: d.functionalOwner.address});
+        await d.contractRegistry.setContracts([contractId("delegations")], [d.delegations.address], [true], {from: d.functionalOwner.address});
 
         let r = await d.delegations.refreshStake(d1.address);
         expect(r).to.have.a.delegatedStakeChangedEvent({
@@ -489,17 +489,17 @@ describe('delegations-contract', async () => {
             delegatedStake: bn(100)
         });
 
-        const otherDelegationContract = await d.web3.deploy("Delegations", [], null, d.session);
+        const otherDelegationContract = await d.web3.deploy("Delegations", [d.contractRegistry.address], null, d.session);
         await otherDelegationContract.setContractRegistry(d.contractRegistry.address);
 
         await d.staking.setStakeChangeNotifier(otherDelegationContract.address);
-        await d.contractRegistry.set("delegations", otherDelegationContract.address, {from: d.functionalOwner.address});
+        await d.contractRegistry.setContracts([contractId("delegations")], [otherDelegationContract.address], [true], {from: d.functionalOwner.address});
 
         r = await d1.stake(200);
         expect(r).to.not.have.withinContract(d.delegations).a.delegatedStakeChangedEvent();
 
         await d.staking.setStakeChangeNotifier(d.delegations.address);
-        await d.contractRegistry.set("delegations", d.delegations.address, {from: d.functionalOwner.address});
+        await d.contractRegistry.setContracts([contractId("delegations")], [d.delegations.address], [true], {from: d.functionalOwner.address});
 
         r = await d1.stake(300);
         expect(r).to.have.a.delegatedStakeChangedEvent({

--- a/test/driver.ts
+++ b/test/driver.ts
@@ -198,7 +198,7 @@ export class Driver {
         const delegations = options.delegationsAddress ?
             await web3.getExisting('Delegations', options.delegationsAddress, session)
             :
-            await web3.deploy("Delegations", [contractRegistry.address], null, session);
+            await web3.deploy("Delegations", [contractRegistry.address, accounts[0]], null, session);
 
         const externalToken = options.bootstrapTokenAddress ?
             await web3.getExisting('TestingERC20', options.bootstrapTokenAddress, session)
@@ -218,32 +218,32 @@ export class Driver {
         const rewards = options.rewardsAddress ?
             await web3.getExisting('Rewards', options.rewardsAddress, session)
             :
-            await web3.deploy('Rewards', [contractRegistry.address, erc20.address, externalToken.address], null, session);
+            await web3.deploy('Rewards', [contractRegistry.address, accounts[0], erc20.address, externalToken.address], null, session);
 
         const elections = options.electionsAddress ?
             await web3.getExisting('Elections', options.electionsAddress, session)
             :
-            await web3.deploy("Elections", [contractRegistry.address, minSelfStakePercentMille, voteUnreadyThreshold, voteUnreadyTimeout, voteOutThreshold], null, session);
+            await web3.deploy("Elections", [contractRegistry.address, accounts[0], minSelfStakePercentMille, voteUnreadyThreshold, voteUnreadyTimeout, voteOutThreshold], null, session);
 
         const subscriptions = options.subscriptionsAddress ?
             await web3.getExisting('Subscriptions', options.subscriptionsAddress, session)
             :
-            await web3.deploy('Subscriptions', [contractRegistry.address, erc20.address], null, session);
+            await web3.deploy('Subscriptions', [contractRegistry.address, accounts[0], erc20.address], null, session);
 
         const protocol = options.protocolAddress ?
             await web3.getExisting('Protocol', options.protocolAddress, session)
             :
-            await web3.deploy('Protocol', [contractRegistry.address], null, session);
+            await web3.deploy('Protocol', [contractRegistry.address, accounts[0]], null, session);
 
         const certification = options.certificationAddress ?
             await web3.getExisting('Certification', options.certificationAddress, session)
             :
-            await web3.deploy('Certification', [contractRegistry.address], null, session);
+            await web3.deploy('Certification', [contractRegistry.address, accounts[0]], null, session);
 
         const committee = options.committeeAddress ?
             await web3.getExisting('Committee', options.committeeAddress, session)
             :
-            await web3.deploy('Committee', [contractRegistry.address, maxCommitteeSize, maxTimeBetweenRewardAssignments], null, session);
+            await web3.deploy('Committee', [contractRegistry.address, accounts[0], maxCommitteeSize, maxTimeBetweenRewardAssignments], null, session);
 
         const stakingRewardsWallet = options.stakingRewardsWalletAddress ?
             await web3.getExisting('ProtocolWallet', options.stakingRewardsWalletAddress, session)
@@ -258,17 +258,17 @@ export class Driver {
         const guardiansRegistration = options.guardiansRegistrationAddress ?
             await web3.getExisting('GuardiansRegistration', options.guardiansRegistrationAddress, session)
             :
-            await web3.deploy('GuardiansRegistration', [contractRegistry.address], null, session);
+            await web3.deploy('GuardiansRegistration', [contractRegistry.address, accounts[0]], null, session);
 
         const generalFeesWallet = options.generalFeesWalletAddress ?
             await web3.getExisting('FeesWallet', options.generalFeesWalletAddress, session)
             :
-            await web3.deploy('FeesWallet', [contractRegistry.address, erc20.address], null, session);
+            await web3.deploy('FeesWallet', [contractRegistry.address, accounts[0], erc20.address], null, session);
 
         const certifiedFeesWallet = options.certifiedFeesWalletAddress ?
             await web3.getExisting('FeesWallet', options.certifiedFeesWalletAddress, session)
             :
-            await web3.deploy('FeesWallet', [contractRegistry.address, erc20.address], null, session);
+            await web3.deploy('FeesWallet', [contractRegistry.address, accounts[0], erc20.address], null, session);
 
         await contractRegistry.setContracts(
             [contractId("staking"),
@@ -447,7 +447,7 @@ export class Driver {
     subscribers: any[] = [];
 
     async newSubscriber(tier: string, monthlyRate:number|BN): Promise<MonthlySubscriptionPlanContract> {
-        const subscriber = await this.web3.deploy('MonthlySubscriptionPlan', [this.contractRegistry.address, this.erc20.address, tier, monthlyRate], null, this.session);
+        const subscriber = await this.web3.deploy('MonthlySubscriptionPlan', [this.contractRegistry.address, this.migrationOwner.address, this.erc20.address, tier, monthlyRate], null, this.session);
         // await subscriber.refreshContracts();
         await subscriber.transferFunctionalOwnership(this.functionalOwner.address);
         await subscriber.claimFunctionalOwnership({from: this.functionalOwner.address});

--- a/test/driver.ts
+++ b/test/driver.ts
@@ -311,8 +311,6 @@ export class Driver {
             contractRegistry,
             stakingRewardsWallet,
             bootstrapRewardsWallet,
-            generalFeesWallet,
-            certifiedFeesWallet
         ].map(async (c: OwnedContract) => {
             await c.transferFunctionalOwnership(accounts[1], {from: accounts[0]});
             await c.claimFunctionalOwnership({from: accounts[1]})

--- a/test/fees-wallet.spec.ts
+++ b/test/fees-wallet.spec.ts
@@ -195,7 +195,7 @@ describe('fees-wallet-contract', async () => {
     let r = await d.generalFeesWallet.fillFeeBuckets(amount, 500, now, {from: assigner.address});
     const buckets = feesAddedToBucketEvents(r);
 
-    const newFeesWallet = await d.web3.deploy('FeesWallet', [d.contractRegistry.address, d.erc20.address], null, d.session);
+    const newFeesWallet = await d.web3.deploy('FeesWallet', [d.contractRegistry.address, d.migrationOwner.address, d.erc20.address], null, d.session);
 
     for (const bucket of buckets) {
       await expectRejected(d.generalFeesWallet.migrateBucket(newFeesWallet.address, bn(bucket.bucketId), {from: d.functionalOwner.address}), /caller is not the migrationOwner/);

--- a/test/guardian-registration.spec.ts
+++ b/test/guardian-registration.spec.ts
@@ -792,8 +792,8 @@ describe('guardian-registration', async () => {
     const v1LastUpdateTime = await d.web3.txTimestamp(r);
     const v2LastUpdateTime = v2RegistrationTime;
 
-    const newContract: GuardiansRegistrationContract = await d.web3.deploy('GuardiansRegistration', [d.contractRegistry.address, d.guardiansRegistration.address, [v1.address, v2.address]], null, d.session);
-    const creationTx = await newContract.getCreationTx()
+    const newContract: GuardiansRegistrationContract = await d.web3.deploy('GuardiansRegistration', [d.contractRegistry.address, d.migrationOwner.address, d.guardiansRegistration.address, [v1.address, v2.address]], null, d.session);
+    const creationTx = await newContract.getCreationTx();
     expect(creationTx).to.have.a.guardianDataUpdatedEvent({
       addr: v1.address,
       orbsAddr: v1.orbsAddress,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -101,3 +101,7 @@ export async function expectRejected(promise: Promise<any>, expectedErrorMsg: Re
     throw new Error("expected promise to reject")
 }
 
+export function contractId(name: string): string /* bytes32 */ {
+    const fromAscii = Web3.utils.fromAscii(name)
+    return fromAscii.length > 66 ? Web3.utils.keccak256(name) : (fromAscii + "0".repeat(66 - fromAscii.length));
+}

--- a/test/staking-contract-handler.spec.ts
+++ b/test/staking-contract-handler.spec.ts
@@ -56,7 +56,7 @@ describe("staking-contract-handler", async () => {
         // Stake migration - both staking contracts will notify, requires a complex setup
         const newRegistry = await d.web3.deploy('ContractRegistry', [], null, d.session);
 
-        const newHandler = await d.web3.deploy('StakingContractHandler', [newRegistry.address], null, d.session);
+        const newHandler = await d.web3.deploy('StakingContractHandler', [newRegistry.address, d.migrationOwner.address], null, d.session);
         await newRegistry.setContract("stakingContractHandler", newHandler.address, true);
 
         const newStaking = await d.newStakingContract(newHandler.address, d.erc20.address);
@@ -107,7 +107,7 @@ describe("staking-contract-handler", async () => {
         // Stake migration - both staking contracts will notify, requires a complex setup
         const newRegistry = await d.web3.deploy('ContractRegistry', [], null, d.session);
 
-        const newHandler = await d.web3.deploy('StakingContractHandler', [newRegistry.address], null, d.session);
+        const newHandler = await d.web3.deploy('StakingContractHandler', [newRegistry.address, d.migrationOwner.address], null, d.session);
         await newRegistry.setContract("stakingContractHandler", newHandler.address, true);
 
         const newStaking = await d.newStakingContract(newHandler.address, d.erc20.address);

--- a/test/staking-rewards.spec.ts
+++ b/test/staking-rewards.spec.ts
@@ -822,7 +822,7 @@ describe('staking-rewards', async () => {
     expect(r).to.not.have.a.stakingRewardsBalanceMigratedEvent();
     expect(bn(await d.rewards.getStakingRewardBalance(v1.address))).to.bignumber.eq(v1balance);
 
-    const newRewardsContract = await d.web3.deploy('Rewards', [d.contractRegistry.address, d.migrationOwner, d.erc20.address, d.bootstrapToken.address], null, d.session);
+    const newRewardsContract = await d.web3.deploy('Rewards', [d.contractRegistry.address, d.migrationOwner.address, d.erc20.address, d.bootstrapToken.address], null, d.session);
     await d.contractRegistry.setContract('rewards', newRewardsContract.address, true, {from: d.functionalOwner.address});
 
     // migrating to the new contract

--- a/test/staking-rewards.spec.ts
+++ b/test/staking-rewards.spec.ts
@@ -822,7 +822,7 @@ describe('staking-rewards', async () => {
     expect(r).to.not.have.a.stakingRewardsBalanceMigratedEvent();
     expect(bn(await d.rewards.getStakingRewardBalance(v1.address))).to.bignumber.eq(v1balance);
 
-    const newRewardsContract = await d.web3.deploy('Rewards', [d.contractRegistry.address, d.erc20.address, d.bootstrapToken.address], null, d.session);
+    const newRewardsContract = await d.web3.deploy('Rewards', [d.contractRegistry.address, d.migrationOwner, d.erc20.address, d.bootstrapToken.address], null, d.session);
     await d.contractRegistry.setContract('rewards', newRewardsContract.address, true, {from: d.functionalOwner.address});
 
     // migrating to the new contract

--- a/test/staking-rewards.spec.ts
+++ b/test/staking-rewards.spec.ts
@@ -822,7 +822,7 @@ describe('staking-rewards', async () => {
     expect(r).to.not.have.a.stakingRewardsBalanceMigratedEvent();
     expect(bn(await d.rewards.getStakingRewardBalance(v1.address))).to.bignumber.eq(v1balance);
 
-    const newRewardsContract = await d.web3.deploy('Rewards', [d.contractRegistry.address, d.erc20.address, d.bootstrapToken.address], null, d.session);
+    const newRewardsContract = await d.web3.deploy('Rewards', [d.contractRegistry.address, d.migrationOwner.address, d.erc20.address, d.bootstrapToken.address], null, d.session);
     await d.contractRegistry.setContracts([contractId('rewards')], [newRewardsContract.address], [true], {from: d.functionalOwner.address});
 
     // migrating to the new contract

--- a/test/staking-rewards.spec.ts
+++ b/test/staking-rewards.spec.ts
@@ -3,7 +3,7 @@ import 'mocha';
 import BN from "bn.js";
 import {Driver} from "./driver";
 import chai from "chai";
-import {bn, bnSum, evmIncreaseTime, evmMine, expectRejected, fromTokenUnits, toTokenUnits} from "./helpers";
+import {bn, bnSum, contractId, evmIncreaseTime, evmMine, expectRejected, fromTokenUnits, toTokenUnits} from "./helpers";
 import {committeeSnapshotEvents} from "./event-parsing";
 
 chai.use(require('chai-bn')(BN));
@@ -822,8 +822,8 @@ describe('staking-rewards', async () => {
     expect(r).to.not.have.a.stakingRewardsBalanceMigratedEvent();
     expect(bn(await d.rewards.getStakingRewardBalance(v1.address))).to.bignumber.eq(v1balance);
 
-    const newRewardsContract = await d.web3.deploy('Rewards', [d.erc20.address, d.bootstrapToken.address], null, d.session);
-    await d.contractRegistry.set('rewards', newRewardsContract.address, {from: d.functionalOwner.address});
+    const newRewardsContract = await d.web3.deploy('Rewards', [d.contractRegistry.address, d.erc20.address, d.bootstrapToken.address], null, d.session);
+    await d.contractRegistry.setContracts([contractId('rewards')], [newRewardsContract.address], [true], {from: d.functionalOwner.address});
 
     // migrating to the new contract
     r = await d.rewards.migrateStakingRewardsBalance(v1.address);

--- a/typings/base-contract.d.ts
+++ b/typings/base-contract.d.ts
@@ -17,5 +17,7 @@ export interface OwnedContract extends Contract {
     lock(params?: TransactionConfig): Promise<TransactionReceipt>;
     unlock(params?: TransactionConfig): Promise<TransactionReceipt>;
 
+    refreshContracts(): Promise<TransactionReceipt>;
+
     setContractRegistry(address: string, params?: TransactionConfig): Promise<TransactionReceipt>;
 }

--- a/typings/contract-registry-contract.d.ts
+++ b/typings/contract-registry-contract.d.ts
@@ -4,12 +4,13 @@ import { ContractName, ContractName4Testkit } from "../test/driver";
 import {OwnedContract} from "./base-contract";
 
 export interface ContractRegistryContract extends OwnedContract {
-  set(contractName: ContractName | ContractName4Testkit, addr: string, params?: TransactionConfig): Promise<TransactionReceipt>;
-  get(contractName: ContractName | ContractName4Testkit, params?: TransactionConfig): Promise<string>;
+  setContracts(contractIds: string[] /* bytes32[] */, addrs: string[], isManaged: boolean[], params?: TransactionConfig): Promise<TransactionReceipt>;
+  getContracts(contractIds: string[] /* bytes32[] */, params?: TransactionConfig): Promise<string[]>;
 }
 
 export interface ContractAddressUpdatedEvent {
-  contractName: ContractName,
-  addr: string
+  contractId: string,
+  addr: string,
+  isManaged: boolean
 }
 


### PR DESCRIPTION
All contracts that use `contractRegistryAccessor` now take the registry manager in the constructor and pass it on the the parent class.