### PR TITLE
Initializable, Managed Contract

### DIFF
--- a/contracts/Certification.sol
+++ b/contracts/Certification.sol
@@ -10,7 +10,7 @@ contract Certification is ICertification, ManagedContract {
 
     mapping (address => bool) guardianCertification;
 
-    constructor(IContractRegistry _contractRegistry, address _registryManager) Lockable(_contractRegistry, _registryManager) public {}
+    constructor(IContractRegistry _contractRegistry, address _registryManager) ManagedContract(_contractRegistry, _registryManager) public {}
 
     /*
      * External methods

--- a/contracts/Certification.sol
+++ b/contracts/Certification.sol
@@ -4,8 +4,9 @@ import "./spec_interfaces/ICertification.sol";
 import "./ContractRegistryAccessor.sol";
 import "./Lockable.sol";
 import "./interfaces/IElections.sol";
+import "./ManagedContract.sol";
 
-contract Certification is ICertification, Lockable {
+contract Certification is ICertification, ManagedContract {
 
     mapping (address => bool) guardianCertification;
 

--- a/contracts/Certification.sol
+++ b/contracts/Certification.sol
@@ -3,6 +3,7 @@ pragma solidity 0.5.16;
 import "./spec_interfaces/ICertification.sol";
 import "./ContractRegistryAccessor.sol";
 import "./Lockable.sol";
+import "./interfaces/IElections.sol";
 
 contract Certification is ICertification, Lockable {
 
@@ -26,7 +27,7 @@ contract Certification is ICertification, Lockable {
 
     IElections electionsContract;
     function refreshContracts() external {
-        electionsContract = getElectionsContract();
+        electionsContract = IElections(getElectionsContract());
     }
 
 }

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -217,7 +217,7 @@ contract Committee is ICommittee, ManagedContract {
 		emit CommitteeSnapshot(committeeAddrs, committeeWeights, committeeCertification);
 	}
 
-	constructor(IContractRegistry _contractRegistry, address _registryManager, uint _maxCommitteeSize, uint32 maxTimeBetweenRewardAssignments) Lockable(_contractRegistry, _registryManager) public {
+	constructor(IContractRegistry _contractRegistry, address _registryManager, uint _maxCommitteeSize, uint32 maxTimeBetweenRewardAssignments) ManagedContract(_contractRegistry, _registryManager) public {
 		require(_maxCommitteeSize > 0, "maxCommitteeSize must be larger than 0");
 		require(_maxCommitteeSize <= MAX_COMMITTEE_ARRAY_SIZE, "maxCommitteeSize must be 32 at most");
 		settings = Settings({

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -6,6 +6,8 @@ import "@openzeppelin/contracts/math/Math.sol";
 import "./ContractRegistryAccessor.sol";
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "./Lockable.sol";
+import "./interfaces/IRewards.sol";
+import "./interfaces/IElections.sol";
 
 /// @title Elections contract interface
 contract Committee is ICommittee, Lockable {
@@ -389,9 +391,9 @@ contract Committee is ICommittee, Lockable {
 	IRewards rewardsContract;
 	IGuardiansRegistration guardianRegistrationContract;
 	function refreshContracts() external {
-		electionsContract = getElectionsContract();
-		rewardsContract = getRewardsContract();
-		guardianRegistrationContract = getGuardiansRegistrationContract();
+		electionsContract = IElections(getElectionsContract());
+		rewardsContract = IRewards(getRewardsContract());
+		guardianRegistrationContract = IGuardiansRegistration(getGuardiansRegistrationContract());
 	}
 
 }

--- a/contracts/Committee.sol
+++ b/contracts/Committee.sol
@@ -8,9 +8,10 @@ import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "./Lockable.sol";
 import "./interfaces/IRewards.sol";
 import "./interfaces/IElections.sol";
+import "./ManagedContract.sol";
 
 /// @title Elections contract interface
-contract Committee is ICommittee, Lockable {
+contract Committee is ICommittee, ManagedContract {
 	using BytesLib for bytes;
 
 	uint constant MAX_COMMITTEE_ARRAY_SIZE = 32; // Cannot be greater than 32 (number of bytes in bytes32)

--- a/contracts/ContractRegistry.sol
+++ b/contracts/ContractRegistry.sol
@@ -13,7 +13,7 @@ contract ContractRegistry is IContractRegistry, Initializable, WithClaimableRegi
 	mapping (string => address) managers;
 
 	modifier onlyManager {
-		require(msg.sender == registryManager() || msg.sender == initializationManager(), "caller is not the registryManager");
+		require(msg.sender == registryManager() || msg.sender == initializationManager(), "sender is not an admin (registryManager or initializationManager)");
 
 		_;
 	}

--- a/contracts/ContractRegistry.sol
+++ b/contracts/ContractRegistry.sol
@@ -2,6 +2,7 @@ pragma solidity 0.5.16;
 import "./spec_interfaces/IContractRegistry.sol";
 import "./IContractRegistryListener.sol";
 import "./WithClaimableRegistryManagement.sol";
+import "./spec_interfaces/ILockable.sol";
 
 contract ContractRegistry is IContractRegistry, WithClaimableRegistryManagement {
 
@@ -19,6 +20,18 @@ contract ContractRegistry is IContractRegistry, WithClaimableRegistryManagement 
 		}
 		emit ContractAddressUpdated(contractName, addr, managedContract);
 		notifyOnContractsChange();
+	}
+
+	function lockContracts() external onlyRegistryManager {
+		for (uint i = 0; i < managedContractAddresses.length; i++) {
+			ILockable(managedContractAddresses[i]).lock();
+		}
+	}
+
+	function unlockContracts() external onlyRegistryManager {
+		for (uint i = 0; i < managedContractAddresses.length; i++) {
+			ILockable(managedContractAddresses[i]).unlock();
+		}
 	}
 
 	function notifyOnContractsChange() private {

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -8,6 +8,12 @@ contract ContractRegistryAccessor is WithClaimableRegistryManagement, Initializa
 
     IContractRegistry contractRegistry;
 
+    modifier onlyAdmin {
+        require(isAdmin(), "sender is not an admin (registryManger or initializationManager)");
+
+        _;
+    }
+
     function isManager(string memory role) internal view returns (bool) {
         IContractRegistry _contractRegistry = contractRegistry;
         return isAdmin() || _contractRegistry != IContractRegistry(0) && contractRegistry.getManager(role) == msg.sender;
@@ -25,8 +31,7 @@ contract ContractRegistryAccessor is WithClaimableRegistryManagement, Initializa
 
     event ContractRegistryAddressUpdated(address addr);
 
-    function setContractRegistry(IContractRegistry _contractRegistry) public {
-        require(isAdmin(), "caller is not the registryManager");
+    function setContractRegistry(IContractRegistry _contractRegistry) public onlyAdmin {
         contractRegistry = _contractRegistry;
         emit ContractRegistryAddressUpdated(address(_contractRegistry));
     }

--- a/contracts/ContractRegistryAccessor.sol
+++ b/contracts/ContractRegistryAccessor.sol
@@ -1,18 +1,7 @@
 pragma solidity 0.5.16;
 
 import "./spec_interfaces/IContractRegistry.sol";
-import "./spec_interfaces/IStakingContractHandler.sol";
-import "./spec_interfaces/IProtocol.sol";
-import "./spec_interfaces/ICommittee.sol";
-import "./interfaces/IElections.sol";
-import "./spec_interfaces/IGuardiansRegistration.sol";
-import "./spec_interfaces/ICertification.sol";
-import "./spec_interfaces/ISubscriptions.sol";
-import "./spec_interfaces/IDelegation.sol";
-import "./spec_interfaces/IFeesWallet.sol";
-import "./interfaces/IRewards.sol";
 import "./WithClaimableRegistryManagement.sol";
-import "./spec_interfaces/IProtocolWallet.sol";
 
 contract ContractRegistryAccessor is WithClaimableRegistryManagement {
 
@@ -54,60 +43,60 @@ contract ContractRegistryAccessor is WithClaimableRegistryManagement {
         emit ContractRegistryAddressUpdated(address(_contractRegistry));
     }
 
-    function getProtocolContract() public view returns (IProtocol) {
-        return IProtocol(contractRegistry.getContract("protocol"));
+    function getProtocolContract() internal view returns (address) {
+        return contractRegistry.getContract("protocol");
     }
 
-    function getRewardsContract() public view returns (IRewards) {
-        return IRewards(contractRegistry.getContract("rewards"));
+    function getRewardsContract() internal view returns (address) {
+        return contractRegistry.getContract("rewards");
     }
 
-    function getCommitteeContract() public view returns (ICommittee) {
-        return ICommittee(contractRegistry.getContract("committee"));
+    function getCommitteeContract() internal view returns (address) {
+        return contractRegistry.getContract("committee");
     }
 
-    function getElectionsContract() public view returns (IElections) {
-        return IElections(contractRegistry.getContract("elections"));
+    function getElectionsContract() internal view returns (address) {
+        return contractRegistry.getContract("elections");
     }
 
-    function getDelegationsContract() public view returns (IDelegations) {
-        return IDelegations(contractRegistry.getContract("delegations"));
+    function getDelegationsContract() internal view returns (address) {
+        return contractRegistry.getContract("delegations");
     }
 
-    function getGuardiansRegistrationContract() public view returns (IGuardiansRegistration) {
-        return IGuardiansRegistration(contractRegistry.getContract("guardiansRegistration"));
+    function getGuardiansRegistrationContract() internal view returns (address) {
+        return contractRegistry.getContract("guardiansRegistration");
     }
 
-    function getCertificationContract() public view returns (ICertification) {
-        return ICertification(contractRegistry.getContract("certification"));
+    function getCertificationContract() internal view returns (address) {
+        return contractRegistry.getContract("certification");
     }
 
-    function getStakingContract() public view returns (IStakingContract) {
-        return IStakingContract(contractRegistry.getContract("staking"));
+    function getStakingContract() internal view returns (address) {
+        return contractRegistry.getContract("staking");
     }
 
-    function getSubscriptionsContract() public view returns (ISubscriptions) {
-        return ISubscriptions(contractRegistry.getContract("subscriptions"));
+    function getSubscriptionsContract() internal view returns (address) {
+        return contractRegistry.getContract("subscriptions");
     }
 
-    function getStakingRewardsWallet() public view returns (IProtocolWallet) {
-        return IProtocolWallet(contractRegistry.getContract("stakingRewardsWallet"));
+    function getStakingRewardsWallet() internal view returns (address) {
+        return contractRegistry.getContract("stakingRewardsWallet");
     }
 
-    function getBootstrapRewardsWallet() public view returns (IProtocolWallet) {
-        return IProtocolWallet(contractRegistry.getContract("bootstrapRewardsWallet"));
+    function getBootstrapRewardsWallet() internal view returns (address) {
+        return contractRegistry.getContract("bootstrapRewardsWallet");
     }
 
-    function getGeneralFeesWallet() public view returns (IFeesWallet) {
-        return IFeesWallet(contractRegistry.getContract("generalFeesWallet"));
+    function getGeneralFeesWallet() internal view returns (address) {
+        return contractRegistry.getContract("generalFeesWallet");
     }
 
-    function getCertifiedFeesWallet() public view returns (IFeesWallet) {
-        return IFeesWallet(contractRegistry.getContract("certifiedFeesWallet"));
+    function getCertifiedFeesWallet() internal view returns (address) {
+        return contractRegistry.getContract("certifiedFeesWallet");
     }
 
-    function getStakingContractHandler() public view returns (IStakingContractHandler) {
-        return IStakingContractHandler(contractRegistry.getContract("stakingContractHandler"));
+    function getStakingContractHandler() internal view returns (address) {
+        return contractRegistry.getContract("stakingContractHandler");
     }
 
 }

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -14,8 +14,9 @@ import "./spec_interfaces/IDelegation.sol";
 import "./IStakeChangeNotifier.sol";
 import "./Lockable.sol";
 import "./spec_interfaces/IStakingContractHandler.sol";
+import "./ManagedContract.sol";
 
-contract Delegations is IDelegations, IStakeChangeNotifier, Lockable {
+contract Delegations is IDelegations, IStakeChangeNotifier, ManagedContract {
 	using SafeMath for uint256;
 	using SafeMath for uint96;
 

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -13,6 +13,7 @@ import "./ContractRegistryAccessor.sol";
 import "./spec_interfaces/IDelegation.sol";
 import "./IStakeChangeNotifier.sol";
 import "./Lockable.sol";
+import "./spec_interfaces/IStakingContractHandler.sol";
 
 contract Delegations is IDelegations, IStakeChangeNotifier, Lockable {
 	using SafeMath for uint256;
@@ -303,8 +304,8 @@ contract Delegations is IDelegations, IStakeChangeNotifier, Lockable {
 	IElections electionsContract;
 	IStakingContractHandler stakingContractHandler;
 	function refreshContracts() external {
-		electionsContract = getElectionsContract();
-		stakingContractHandler = getStakingContractHandler();
+		electionsContract = IElections(getElectionsContract());
+		stakingContractHandler = IStakingContractHandler(getStakingContractHandler());
 	}
 
 }

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -36,7 +36,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ManagedContract {
 		_;
 	}
 
-	constructor(IContractRegistry _contractRegistry, address _registryManager) Lockable(_contractRegistry, _registryManager) public {}
+	constructor(IContractRegistry _contractRegistry, address _registryManager) ManagedContract(_contractRegistry, _registryManager) public {}
 
 	function getTotalDelegatedStake() external view returns (uint256) {
 		return totalDelegatedStake;

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -12,9 +12,10 @@ import "./spec_interfaces/ICommittee.sol";
 import "./spec_interfaces/ICertification.sol";
 import "./ContractRegistryAccessor.sol";
 import "./Lockable.sol";
+import "./ManagedContract.sol";
 
 
-contract Elections is IElections, Lockable {
+contract Elections is IElections, ManagedContract {
 	using SafeMath for uint256;
 
 	mapping (address => mapping (address => uint256)) votedUnreadyVotes; // by => to => timestamp

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -44,7 +44,7 @@ contract Elections is IElections, ManagedContract {
 		_;
 	}
 
-	constructor(IContractRegistry _contractRegistry, address _registryManager, uint32 minSelfStakePercentMille, uint8 voteUnreadyPercentageThreshold, uint32 voteUnreadyTimeoutSeconds, uint8 voteOutPercentageThreshold) Lockable(_contractRegistry, _registryManager) public {
+	constructor(IContractRegistry _contractRegistry, address _registryManager, uint32 minSelfStakePercentMille, uint8 voteUnreadyPercentageThreshold, uint32 voteUnreadyTimeoutSeconds, uint8 voteOutPercentageThreshold) ManagedContract(_contractRegistry, _registryManager) public {
 		require(minSelfStakePercentMille <= 100000, "minSelfStakePercentMille must be at most 100000");
 		require(voteUnreadyPercentageThreshold >= 0 && voteUnreadyPercentageThreshold <= 100, "voteUnreadyPercentageThreshold must be between 0 and 100");
 		require(voteOutPercentageThreshold >= 0 && voteOutPercentageThreshold <= 100, "voteOutPercentageThreshold must be between 0 and 100");

--- a/contracts/Elections.sol
+++ b/contracts/Elections.sol
@@ -311,11 +311,11 @@ contract Elections is IElections, Lockable {
 	IStakingContract stakingContract;
 	ICertification certificationContract;
 	function refreshContracts() external {
-		committeeContract = getCommitteeContract();
-		delegationsContract = getDelegationsContract();
-		guardianRegistrationContract = getGuardiansRegistrationContract();
-		stakingContract = getStakingContract();
-		certificationContract = getCertificationContract();
+		committeeContract = ICommittee(getCommitteeContract());
+		delegationsContract = IDelegations(getDelegationsContract());
+		guardianRegistrationContract = IGuardiansRegistration(getGuardiansRegistrationContract());
+		stakingContract = IStakingContract(getStakingContract());
+		certificationContract = ICertification(getCertificationContract());
 	}
 
 }

--- a/contracts/FeesWallet.sol
+++ b/contracts/FeesWallet.sol
@@ -10,10 +10,11 @@ import "./ContractRegistryAccessor.sol";
 import "./spec_interfaces/IFeesWallet.sol";
 import "./interfaces/IRewards.sol";
 import "./Lockable.sol";
+import "./ManagedContract.sol";
 
 
 /// @title Fees Wallet contract interface, manages the fee buckets
-contract FeesWallet is IFeesWallet, Lockable {
+contract FeesWallet is IFeesWallet, ManagedContract {
     using SafeMath for uint256;
 
     event FeesWithdrawnFromBucket(uint256 bucketId, uint256 withdrawn, uint256 total);

--- a/contracts/FeesWallet.sol
+++ b/contracts/FeesWallet.sol
@@ -9,10 +9,11 @@ import "./spec_interfaces/IMigratableFeesWallet.sol";
 import "./ContractRegistryAccessor.sol";
 import "./spec_interfaces/IFeesWallet.sol";
 import "./interfaces/IRewards.sol";
+import "./Lockable.sol";
 
 
 /// @title Fees Wallet contract interface, manages the fee buckets
-contract FeesWallet is IFeesWallet, ContractRegistryAccessor {
+contract FeesWallet is IFeesWallet, Lockable {
     using SafeMath for uint256;
 
     event FeesWithdrawnFromBucket(uint256 bucketId, uint256 withdrawn, uint256 total);
@@ -32,7 +33,7 @@ contract FeesWallet is IFeesWallet, ContractRegistryAccessor {
         _;
     }
 
-    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _token) ContractRegistryAccessor(_contractRegistry, _registryManager) public {
+    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _token) Lockable(_contractRegistry, _registryManager) public {
         token = _token;
         lastCollectedAt = now;
     }

--- a/contracts/FeesWallet.sol
+++ b/contracts/FeesWallet.sol
@@ -34,7 +34,7 @@ contract FeesWallet is IFeesWallet, ManagedContract {
         _;
     }
 
-    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _token) Lockable(_contractRegistry, _registryManager) public {
+    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _token) ManagedContract(_contractRegistry, _registryManager) public {
         token = _token;
         lastCollectedAt = now;
     }

--- a/contracts/FeesWallet.sol
+++ b/contracts/FeesWallet.sol
@@ -8,6 +8,7 @@ import "./spec_interfaces/IContractRegistry.sol";
 import "./spec_interfaces/IMigratableFeesWallet.sol";
 import "./ContractRegistryAccessor.sol";
 import "./spec_interfaces/IFeesWallet.sol";
+import "./interfaces/IRewards.sol";
 
 
 /// @title Fees Wallet contract interface, manages the fee buckets
@@ -153,7 +154,7 @@ contract FeesWallet is IFeesWallet, ContractRegistryAccessor {
 
     IRewards rewardsContract;
     function refreshContracts() external {
-        rewardsContract = getRewardsContract();
+        rewardsContract = IRewards(getRewardsContract());
     }
 
 }

--- a/contracts/GuardiansRegistration.sol
+++ b/contracts/GuardiansRegistration.sol
@@ -208,7 +208,7 @@ contract GuardiansRegistration is IGuardiansRegistration, Lockable {
 
 	IElections electionsContract;
 	function refreshContracts() external {
-		electionsContract = getElectionsContract();
+		electionsContract = IElections(getElectionsContract());
 	}
 
 }

--- a/contracts/GuardiansRegistration.sol
+++ b/contracts/GuardiansRegistration.sol
@@ -4,8 +4,9 @@ import "./spec_interfaces/IGuardiansRegistration.sol";
 import "./interfaces/IElections.sol";
 import "./ContractRegistryAccessor.sol";
 import "./Lockable.sol";
+import "./ManagedContract.sol";
 
-contract GuardiansRegistration is IGuardiansRegistration, Lockable {
+contract GuardiansRegistration is IGuardiansRegistration, ManagedContract {
 
 	modifier onlyRegisteredGuardian {
 		require(isRegistered(msg.sender), "Guardian is not registered");

--- a/contracts/GuardiansRegistration.sol
+++ b/contracts/GuardiansRegistration.sol
@@ -28,7 +28,7 @@ contract GuardiansRegistration is IGuardiansRegistration, ManagedContract {
 	mapping (bytes4 => address) public ipToGuardian;
 	mapping (address => mapping(string => string)) public guardianMetadata;
 
-	constructor(IContractRegistry _contractRegistry, address _registryManager, IGuardiansRegistration previousContract, address[] memory guardiansToMigrate) Lockable(_contractRegistry, _registryManager) public {
+	constructor(IContractRegistry _contractRegistry, address _registryManager, IGuardiansRegistration previousContract, address[] memory guardiansToMigrate) ManagedContract(_contractRegistry, _registryManager) public {
 		require(previousContract != IGuardiansRegistration(0) || guardiansToMigrate.length == 0, "A guardian address list was provided for migration without the previous contract");
 
 		for (uint i = 0; i < guardiansToMigrate.length; i++) {

--- a/contracts/Initializable.sol
+++ b/contracts/Initializable.sol
@@ -1,0 +1,20 @@
+pragma solidity 0.5.16;
+
+contract Initializable {
+
+    address public _initializationManager;
+
+    constructor() public{
+        _initializationManager = msg.sender;
+    }
+
+    function initializationManager() public view returns (address) {
+        return _initializationManager;
+    }
+
+    function initializationComplete() external {
+        require(msg.sender == initializationManager(), "caller is not the initialization manager");
+
+        _initializationManager = address(0);
+    }
+}

--- a/contracts/Initializable.sol
+++ b/contracts/Initializable.sol
@@ -4,6 +4,8 @@ contract Initializable {
 
     address public _initializationManager;
 
+    event InitializationComplete();
+
     constructor() public{
         _initializationManager = msg.sender;
     }
@@ -14,7 +16,7 @@ contract Initializable {
 
     function initializationComplete() external {
         require(msg.sender == initializationManager(), "caller is not the initialization manager");
-
         _initializationManager = address(0);
+        emit InitializationComplete();
     }
 }

--- a/contracts/Lockable.sol
+++ b/contracts/Lockable.sol
@@ -1,13 +1,11 @@
 pragma solidity 0.5.16;
 
 import "./ContractRegistryAccessor.sol";
+import "./spec_interfaces/ILockable.sol";
 
-contract Lockable is ContractRegistryAccessor {
+contract Lockable is ILockable, ContractRegistryAccessor {
 
     bool public locked;
-
-    event Locked();
-    event Unlocked();
 
     modifier onlyLockOwner() {
         require(msg.sender == registryManager() || msg.sender == address(contractRegistry), "caller is not a lock owner");
@@ -25,6 +23,10 @@ contract Lockable is ContractRegistryAccessor {
     function unlock() external onlyLockOwner {
         locked = false;
         emit Unlocked();
+    }
+
+    function isLocked() external view returns (bool) {
+        return locked;
     }
 
     modifier onlyWhenActive() {

--- a/contracts/ManagedContract.sol
+++ b/contracts/ManagedContract.sol
@@ -4,6 +4,8 @@ import "./Lockable.sol";
 
 contract ManagedContract is Lockable {
 
+    constructor(IContractRegistry _contractRegistry, address _registryManager) Lockable(_contractRegistry, _registryManager) public {}
+
     modifier onlyMigrationManager {
         require(isManager("migrationManager"), "sender is not the migration manager");
 
@@ -21,6 +23,5 @@ contract ManagedContract is Lockable {
 
         _;
     }
-
 
 }

--- a/contracts/ManagedContract.sol
+++ b/contracts/ManagedContract.sol
@@ -1,0 +1,26 @@
+pragma solidity 0.5.16;
+
+import "./Lockable.sol";
+
+contract ManagedContract is Lockable {
+
+    modifier onlyMigrationManager {
+        require(isManager("migrationManager"), "sender is not the migration manager");
+
+        _;
+    }
+
+    modifier onlyFunctionalManager {
+        require(isManager("functionalManager"), "sender is not the functional manager");
+
+        _;
+    }
+
+    modifier onlyEmergencyManager {
+        require(isManager("emergencyManager"), "sender is not the emergency manager");
+
+        _;
+    }
+
+
+}

--- a/contracts/MonthlySubscriptionPlan.sol
+++ b/contracts/MonthlySubscriptionPlan.sol
@@ -24,7 +24,7 @@ contract MonthlySubscriptionPlan is ContractRegistryAccessor {
     function createVC(string calldata name, uint256 amount, bool isCertified, string calldata deploymentSubset) external {
         require(amount > 0, "must include funds");
 
-        ISubscriptions subs = getSubscriptionsContract();
+        ISubscriptions subs = ISubscriptions(getSubscriptionsContract());
         require(erc20.transferFrom(msg.sender, address(this), amount), "failed to transfer subscription fees");
         require(erc20.approve(address(subs), amount), "failed to transfer subscription fees");
         subs.createVC(name, tier, monthlyRate, amount, msg.sender, isCertified, deploymentSubset);
@@ -33,7 +33,7 @@ contract MonthlySubscriptionPlan is ContractRegistryAccessor {
     function extendSubscription(uint256 vcid, uint256 amount) external {
         require(amount > 0, "must include funds");
 
-        ISubscriptions subs = getSubscriptionsContract();
+        ISubscriptions subs = ISubscriptions(getSubscriptionsContract());
 
         require(erc20.transferFrom(msg.sender, address(this), amount), "failed to transfer subscription fees from vc payer to subscriber");
         require(erc20.approve(address(subs), amount), "failed to approve subscription fees to subscriptions by subscriber");

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -16,7 +16,7 @@ contract Protocol is IProtocol, ManagedContract {
 
     mapping (string => DeploymentSubset) deploymentSubsets;
 
-    constructor(IContractRegistry _contractRegistry, address _registryManager) Lockable(_contractRegistry, _registryManager) public {}
+    constructor(IContractRegistry _contractRegistry, address _registryManager) ManagedContract(_contractRegistry, _registryManager) public {}
 
     function deploymentSubsetExists(string calldata deploymentSubset) external view returns (bool) {
         return deploymentSubsets[deploymentSubset].exists;

--- a/contracts/Protocol.sol
+++ b/contracts/Protocol.sol
@@ -3,8 +3,9 @@ pragma solidity 0.5.16;
 import "./spec_interfaces/IProtocol.sol";
 import "./ContractRegistryAccessor.sol";
 import "./Lockable.sol";
+import "./ManagedContract.sol";
 
-contract Protocol is IProtocol, Lockable {
+contract Protocol is IProtocol, ManagedContract {
 
     struct DeploymentSubset {
         bool exists;

--- a/contracts/ProtocolWallet.sol
+++ b/contracts/ProtocolWallet.sol
@@ -3,8 +3,9 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./spec_interfaces/IProtocolWallet.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./ContractRegistryAccessor.sol";
+import "./Lockable.sol";
 
-contract ProtocolWallet is IProtocolWallet, ContractRegistryAccessor {
+contract ProtocolWallet is IProtocolWallet, Lockable {
     using SafeMath for uint256;
 
     IERC20 public token;
@@ -19,7 +20,7 @@ contract ProtocolWallet is IProtocolWallet, ContractRegistryAccessor {
         _;
     }
 
-    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _token, address _client) ContractRegistryAccessor(_contractRegistry, _registryManager) public {
+    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _token, address _client) Lockable(_contractRegistry, _registryManager) public {
         token = _token;
         client = _client;
         lastWithdrawal = now; // TODO init here, or in first call to setMaxAnnualRate?

--- a/contracts/ProtocolWallet.sol
+++ b/contracts/ProtocolWallet.sol
@@ -4,8 +4,9 @@ import "./spec_interfaces/IProtocolWallet.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./ContractRegistryAccessor.sol";
 import "./Lockable.sol";
+import "./ManagedContract.sol";
 
-contract ProtocolWallet is IProtocolWallet, Lockable {
+contract ProtocolWallet is IProtocolWallet, ManagedContract {
     using SafeMath for uint256;
 
     IERC20 public token;

--- a/contracts/ProtocolWallet.sol
+++ b/contracts/ProtocolWallet.sol
@@ -21,7 +21,7 @@ contract ProtocolWallet is IProtocolWallet, ManagedContract {
         _;
     }
 
-    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _token, address _client) Lockable(_contractRegistry, _registryManager) public {
+    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _token, address _client) ManagedContract(_contractRegistry, _registryManager) public {
         token = _token;
         client = _client;
         lastWithdrawal = now; // TODO init here, or in first call to setMaxAnnualRate?

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -44,7 +44,7 @@ contract Rewards is IRewards, ERC20AccessorWithTokenGranularity, ManagedContract
         _;
     }
 
-    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _erc20, IERC20 _bootstrapToken) Lockable(_contractRegistry, _registryManager) public {
+    constructor(IContractRegistry _contractRegistry, address _registryManager, IERC20 _erc20, IERC20 _bootstrapToken) ManagedContract(_contractRegistry, _registryManager) public {
         require(address(_bootstrapToken) != address(0), "bootstrapToken must not be 0");
         require(address(_erc20) != address(0), "erc20 must not be 0");
 

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -276,7 +276,7 @@ contract Rewards is IRewards, ERC20AccessorWithTokenGranularity, Lockable {
     }
 
     function migrateStakingRewardsBalance(address guardian) external {
-        IRewards currentRewardsContract = getRewardsContract();
+        IRewards currentRewardsContract = IRewards(getRewardsContract());
         if (currentRewardsContract == this) {
             return;
         }
@@ -315,14 +315,14 @@ contract Rewards is IRewards, ERC20AccessorWithTokenGranularity, Lockable {
     IProtocolWallet stakingRewardsWallet;
     IProtocolWallet bootstrapRewardsWallet;
     function refreshContracts() external {
-        committeeContract = getCommitteeContract();
-        delegationsContract = getDelegationsContract();
-        guardianRegistrationContract = getGuardiansRegistrationContract();
-        stakingContract = getStakingContract();
-        generalFeesWallet = getGeneralFeesWallet();
-        certifiedFeesWallet = getCertifiedFeesWallet();
-        stakingRewardsWallet = getStakingRewardsWallet();
-        bootstrapRewardsWallet = getBootstrapRewardsWallet();
+        committeeContract = ICommittee(getCommitteeContract());
+        delegationsContract = IDelegations(getDelegationsContract());
+        guardianRegistrationContract = IGuardiansRegistration(getGuardiansRegistrationContract());
+        stakingContract = IStakingContract(getStakingContract());
+        generalFeesWallet = IFeesWallet(getGeneralFeesWallet());
+        certifiedFeesWallet = IFeesWallet(getCertifiedFeesWallet());
+        stakingRewardsWallet = IProtocolWallet(getStakingRewardsWallet());
+        bootstrapRewardsWallet = IProtocolWallet(getBootstrapRewardsWallet());
     }
 
 }

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -11,8 +11,9 @@ import "./ContractRegistryAccessor.sol";
 import "./Erc20AccessorWithTokenGranularity.sol";
 import "./spec_interfaces/IFeesWallet.sol";
 import "./Lockable.sol";
+import "./ManagedContract.sol";
 
-contract Rewards is IRewards, ERC20AccessorWithTokenGranularity, Lockable {
+contract Rewards is IRewards, ERC20AccessorWithTokenGranularity, ManagedContract {
     using SafeMath for uint256;
     using SafeMath for uint48;
 

--- a/contracts/StakingContractHandler.sol
+++ b/contracts/StakingContractHandler.sol
@@ -4,12 +4,13 @@ import "./ContractRegistryAccessor.sol";
 import "./spec_interfaces/IStakingContractHandler.sol";
 import "./IStakeChangeNotifier.sol";
 import "./IStakingContract.sol";
+import "./Lockable.sol";
 
-contract StakingContractHandler is IStakingContractHandler, IStakeChangeNotifier, ContractRegistryAccessor {
+contract StakingContractHandler is IStakingContractHandler, IStakeChangeNotifier, Lockable {
 
     uint constant NOTIFICATION_GAS_LIMIT = 5000000;
 
-    constructor(IContractRegistry _contractRegistry, address _registryManager) public ContractRegistryAccessor(_contractRegistry, _registryManager) {}
+    constructor(IContractRegistry _contractRegistry, address _registryManager) public Lockable(_contractRegistry, _registryManager) {}
 
     modifier onlyStakingContract() {
         require(msg.sender == address(getStakingContract()), "caller is not the staking contract");

--- a/contracts/StakingContractHandler.sol
+++ b/contracts/StakingContractHandler.sol
@@ -2,6 +2,8 @@ pragma solidity 0.5.16;
 
 import "./ContractRegistryAccessor.sol";
 import "./spec_interfaces/IStakingContractHandler.sol";
+import "./IStakeChangeNotifier.sol";
+import "./IStakingContract.sol";
 
 contract StakingContractHandler is IStakingContractHandler, IStakeChangeNotifier, ContractRegistryAccessor {
 
@@ -54,20 +56,20 @@ contract StakingContractHandler is IStakingContractHandler, IStakeChangeNotifier
     /// @param _stakeOwner address The address to check.
     /// @return uint256 The total stake.
     function getStakeBalanceOf(address _stakeOwner) external view returns (uint256) {
-        return getStakingContract().getStakeBalanceOf(_stakeOwner);
+        return stakingContract.getStakeBalanceOf(_stakeOwner);
     }
 
     /// @dev Returns the total amount staked tokens (excluding unstaked tokens).
     /// @return uint256 The total staked tokens of all stake owners.
     function getTotalStakedTokens() external view returns (uint256) {
-        return getStakingContract().getTotalStakedTokens();
+        return stakingContract.getTotalStakedTokens();
     }
 
     IStakeChangeNotifier delegationsContract;
     IStakingContract stakingContract;
     function refreshContracts() external {
-        delegationsContract = IStakeChangeNotifier(address(getDelegationsContract()));
-        stakingContract = getStakingContract();
+        delegationsContract = IStakeChangeNotifier(getDelegationsContract());
+        stakingContract = IStakingContract(getStakingContract());
     }
 
 }

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -38,7 +38,7 @@ contract Subscriptions is ISubscriptions, ManagedContract {
 
     IERC20 public erc20;
 
-    constructor (IContractRegistry _contractRegistry, address _registryManager, IERC20 _erc20) Lockable(_contractRegistry, _registryManager) public {
+    constructor (IContractRegistry _contractRegistry, address _registryManager, IERC20 _erc20) ManagedContract(_contractRegistry, _registryManager) public {
         require(address(_erc20) != address(0), "erc20 must not be 0");
 
         nextVcid = 1000000;

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -6,8 +6,9 @@ import "./spec_interfaces/IProtocol.sol";
 import "./ContractRegistryAccessor.sol";
 import "./spec_interfaces/IFeesWallet.sol";
 import "./Lockable.sol";
+import "./ManagedContract.sol";
 
-contract Subscriptions is ISubscriptions, Lockable {
+contract Subscriptions is ISubscriptions, ManagedContract {
     using SafeMath for uint256;
 
     enum CommitteeType {

--- a/contracts/Subscriptions.sol
+++ b/contracts/Subscriptions.sol
@@ -163,9 +163,9 @@ contract Subscriptions is ISubscriptions, Lockable {
     IFeesWallet certifiedFeesWallet;
     IProtocol protocolContract;
     function refreshContracts() external {
-        generalFeesWallet = getGeneralFeesWallet();
-        certifiedFeesWallet = getCertifiedFeesWallet();
-        protocolContract = getProtocolContract();
+        generalFeesWallet = IFeesWallet(getGeneralFeesWallet());
+        certifiedFeesWallet = IFeesWallet(getCertifiedFeesWallet());
+        protocolContract = IProtocol(getProtocolContract());
     }
 
 }

--- a/contracts/WithClaimableRegistryManagement.sol
+++ b/contracts/WithClaimableRegistryManagement.sol
@@ -80,6 +80,7 @@ contract WithClaimableRegistryManagement is Context {
     function transferRegistryManagement(address newRegistryManager) public onlyRegistryManager {
         pendingRegistryManager = newRegistryManager;
     }
+
     /**
      * @dev Allows the pendingRegistryManager address to finalize the transfer.
      */

--- a/contracts/for_testing/ManagedContractTest.sol
+++ b/contracts/for_testing/ManagedContractTest.sol
@@ -2,7 +2,7 @@ pragma solidity 0.5.16;
 
 import "../ContractRegistryAccessor.sol";
 
-contract ManagedContract is ContractRegistryAccessor {
+contract ManagedContractTest is ContractRegistryAccessor {
 
     constructor(IContractRegistry _contractRegistry, address _registryManager) ContractRegistryAccessor(_contractRegistry, _registryManager) public {}
 

--- a/contracts/for_testing/ManagedContractTest.sol
+++ b/contracts/for_testing/ManagedContractTest.sol
@@ -1,14 +1,22 @@
 pragma solidity 0.5.16;
 
 import "../ContractRegistryAccessor.sol";
+import "../ManagedContract.sol";
 
-contract ManagedContractTest is ContractRegistryAccessor {
+contract ManagedContractTest is ManagedContract {
 
-    constructor(IContractRegistry _contractRegistry, address _registryManager) ContractRegistryAccessor(_contractRegistry, _registryManager) public {}
+    constructor(IContractRegistry _contractRegistry, address _registryManager) ManagedContract(_contractRegistry, _registryManager) public {}
 
     uint public refreshContractsCount;
 
     function refreshContracts() external {
         refreshContractsCount++;
     }
+
+    function adminOp() external view onlyAdmin {}
+    function migrationManagerOp() external view onlyMigrationManager {}
+    function nonExistentManagerOp() external view {
+        require(isManager("nonexistentrole"), "sender is not the manager");
+    }
+
 }

--- a/contracts/spec_interfaces/IContractRegistry.sol
+++ b/contracts/spec_interfaces/IContractRegistry.sol
@@ -19,4 +19,8 @@ interface IContractRegistry {
 
 	function getManager(string calldata role) external view returns (address);
 
+	function lockContracts() external /* onlyRegistryManager */;
+
+	function unlockContracts() external /* onlyRegistryManager */;
+
 }

--- a/contracts/spec_interfaces/IContractRegistry.sol
+++ b/contracts/spec_interfaces/IContractRegistry.sol
@@ -7,7 +7,7 @@ interface IContractRegistry {
 
 	/// @dev updates the contracts address and emits a corresponding event
 	/// managedContract indicates whether the contract is managed by the registry and notified on changes
-	function setContract(string calldata contractName, address addr, bool managedContract) external /* onlyRegistryManager */;
+	function setContract(string calldata contractName, address addr, bool managedContract) external /* onlyAdmin */;
 
 	/// @dev returns the current address of the given contracts
 	function getContract(string calldata contractName) external view returns (address);
@@ -15,12 +15,12 @@ interface IContractRegistry {
 	/// @dev returns the list of contract addresses managed by the registry
 	function getManagedContracts() external view returns (address[] memory);
 
-	function setManager(string calldata role, address manager) external /* onlyRegistryManager */;
+	function setManager(string calldata role, address manager) external /* onlyAdmin */;
 
 	function getManager(string calldata role) external view returns (address);
 
-	function lockContracts() external /* onlyRegistryManager */;
+	function lockContracts() external /* onlyAdmin */;
 
-	function unlockContracts() external /* onlyRegistryManager */;
+	function unlockContracts() external /* onlyAdmin */;
 
 }

--- a/contracts/spec_interfaces/ILockable.sol
+++ b/contracts/spec_interfaces/ILockable.sol
@@ -1,0 +1,12 @@
+pragma solidity 0.5.16;
+
+interface ILockable {
+
+    event Locked();
+    event Unlocked();
+
+    function lock() external /* onlyLockOwner */;
+    function unlock() external /* onlyLockOwner */;
+    function isLocked() view external returns (bool);
+
+}

--- a/test/contract-registry.spec.ts
+++ b/test/contract-registry.spec.ts
@@ -4,6 +4,7 @@ import BN from "bn.js";
 import {Driver, ZERO_ADDR} from "./driver";
 import chai from "chai";
 import {bn, contractId, expectRejected} from "./helpers";
+import {ContractRegistryContract} from "../typings/contract-registry-contract";
 
 chai.use(require('chai-bn')(BN));
 chai.use(require('./matchers'));
@@ -47,7 +48,7 @@ describe('contract-registry-high-level-flows', async () => {
     const nonGovernor = d.newParticipant();
     const contract2Name = "committee";
     const addr3 = d.newParticipant().address;
-    await expectRejected(registry.setContract(contract2Name, addr3, false, {from: nonGovernor.address}), /caller is not the registryManager/);
+    await expectRejected(registry.setContract(contract2Name, addr3, false, {from: nonGovernor.address}), /sender is not an admin/);
 
     // now by governor
     r = await registry.setContract(contract2Name, addr3, false, {from: owner.address});
@@ -65,10 +66,10 @@ describe('contract-registry-high-level-flows', async () => {
     const subscriber = await d.newSubscriber("tier", 1);
 
     const newAddr = d.newParticipant().address;
-    await expectRejected(d.elections.setContractRegistry(newAddr, {from: d.functionalManager.address}), /caller is not the registryManager/);
-    await expectRejected(d.rewards.setContractRegistry(newAddr, {from: d.functionalManager.address}), /caller is not the registryManager/);
-    await expectRejected(d.subscriptions.setContractRegistry(newAddr, {from: d.functionalManager.address}), /caller is not the registryManager/);
-    await expectRejected(subscriber.setContractRegistry(newAddr, {from: d.functionalManager.address}), /caller is not the registryManager/);
+    await expectRejected(d.elections.setContractRegistry(newAddr, {from: d.functionalManager.address}), /sender is not an admin/);
+    await expectRejected(d.rewards.setContractRegistry(newAddr, {from: d.functionalManager.address}), /sender is not an admin/);
+    await expectRejected(d.subscriptions.setContractRegistry(newAddr, {from: d.functionalManager.address}), /sender is not an admin/);
+    await expectRejected(subscriber.setContractRegistry(newAddr, {from: d.functionalManager.address}), /sender is not an admin/);
 
     let r = await d.elections.setContractRegistry(newAddr, {from: d.registryManager.address});
     expect(r).to.have.a.contractRegistryAddressUpdatedEvent({addr: newAddr});
@@ -86,7 +87,7 @@ describe('contract-registry-high-level-flows', async () => {
     const p = d.newParticipant();
 
     const nonOwner = d.newParticipant();
-    await expectRejected(d.contractRegistry.setManager("newRole", p.address, {from: nonOwner.address}), /caller is not the registryManager/);
+    await expectRejected(d.contractRegistry.setManager("newRole", p.address, {from: nonOwner.address}), /sender is not an admin/);
 
     let r = await d.contractRegistry.setManager("newRole", p.address, {from: d.registryManager.address});
     expect(r).to.have.a.managerChangedEvent({
@@ -152,19 +153,62 @@ describe('contract-registry-high-level-flows', async () => {
 
     const managedContracts = await d.contractRegistry.getManagedContracts();
 
-    await expectRejected(d.contractRegistry.lockContracts({from: d.migrationManager.address}), /caller is not the registryManager/);
+    await expectRejected(d.contractRegistry.lockContracts({from: d.migrationManager.address}), /sender is not an admin/);
     await d.contractRegistry.lockContracts({from: d.registryManager.address});
     for (const contractAddr of managedContracts) {
       const contract = d.web3.getExisting("Lockable" as any, contractAddr);
       expect(await contract.isLocked()).to.be.true;
     }
 
-    await expectRejected(d.contractRegistry.unlockContracts({from: d.migrationManager.address}), /caller is not the registryManager/);
+    await expectRejected(d.contractRegistry.unlockContracts({from: d.migrationManager.address}), /sender is not an admin/);
     await d.contractRegistry.unlockContracts({from: d.registryManager.address});
     for (const contractAddr of managedContracts) {
       const contract = d.web3.getExisting("Lockable" as any, contractAddr);
       expect(await contract.isLocked()).to.be.false;
     }
+  });
+
+  it('allows the initialization manager to setContract,setRole,lock,unlock until initialization complete', async () => {
+    const d = await Driver.new();
+
+    const registry: ContractRegistryContract = await d.web3.deploy('ContractRegistry', [d.registryManager.address], {from: d.initializationManager.address});
+    const managed =  await d.web3.deploy('ManagedContractTest' as any, [registry.address, d.registryManager.address]);
+
+    const manager = d.newParticipant().address;
+
+    let r = await registry.setContract('name', managed.address, true, {from: d.initializationManager.address});
+    expect(r).to.have.a.contractAddressUpdatedEvent();
+    r = await registry.setManager('role', manager, {from: d.initializationManager.address});
+    expect(r).to.have.a.managerChangedEvent();
+    r = await registry.lockContracts({from: d.initializationManager.address});
+    expect(r).to.have.a.lockedEvent();
+    r = await registry.unlockContracts({from: d.initializationManager.address});
+    expect(r).to.have.a.unlockedEvent();
+
+    r = await registry.setContract('name', managed.address, true, {from: d.registryManager.address});
+    expect(r).to.have.a.contractAddressUpdatedEvent();
+    r = await registry.setManager('role', manager, {from: d.registryManager.address});
+    expect(r).to.have.a.managerChangedEvent();
+    r = await registry.lockContracts({from: d.registryManager.address});
+    expect(r).to.have.a.lockedEvent();
+    r = await registry.unlockContracts({from: d.registryManager.address});
+    expect(r).to.have.a.unlockedEvent();
+
+    await registry.initializationComplete();
+
+    await expectRejected(registry.setContract('name', managed.address, true, {from: d.initializationManager.address}), /sender is not an admin/);
+    await expectRejected(registry.setManager('role', manager, {from: d.initializationManager.address}), /sender is not an admin/);
+    await expectRejected(registry.lockContracts({from: d.initializationManager.address}), /sender is not an admin/);
+    await expectRejected(registry.unlockContracts({from: d.initializationManager.address}), /sender is not an admin/);
+
+    r = await registry.setContract('name', managed.address, true, {from: d.registryManager.address});
+    expect(r).to.have.a.contractAddressUpdatedEvent();
+    r = await registry.setManager('role', manager, {from: d.registryManager.address});
+    expect(r).to.have.a.managerChangedEvent();
+    r = await registry.lockContracts({from: d.registryManager.address});
+    expect(r).to.have.a.lockedEvent();
+    r = await registry.unlockContracts({from: d.registryManager.address});
+    expect(r).to.have.a.unlockedEvent();
   });
 
 });

--- a/test/initializable.spec.ts
+++ b/test/initializable.spec.ts
@@ -1,0 +1,50 @@
+import 'mocha';
+
+import * as _ from "lodash";
+import BN from "bn.js";
+import {Driver, DEPLOYMENT_SUBSET_MAIN, Participant} from "./driver";
+import chai from "chai";
+import {
+    feesAddedToBucketEvents, feesAssignedEvents,
+    subscriptionChangedEvents,
+    vcCreatedEvents
+} from "./event-parsing";
+import {bn, bnSum, evmIncreaseTime, expectRejected, fromTokenUnits, toTokenUnits} from "./helpers";
+import {FeesAddedToBucketEvent} from "../typings/fees-wallet-contract";
+import {FeesAssignedEvent} from "../typings/rewards-contract";
+
+chai.use(require('chai-bn')(BN));
+chai.use(require('./matchers'));
+
+const MONTH_IN_SECONDS = 30*24*60*60;
+
+const expect = chai.expect;
+
+async function sleep(ms): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('initializable', async () => {
+
+    it('should allow the initializer to act as all roles until init complete', async () => {
+        const d = await Driver.new();
+
+        const managed = await d.web3.deploy('ManagedContractTest' as any, [d.contractRegistry.address, d.registryManager.address]);
+
+        await managed.adminOp({from: d.initializationManager.address});
+        await managed.adminOp({from: d.registryManager.address});
+        await managed.migrationManagerOp({from: d.initializationManager.address});
+        await managed.migrationManagerOp({from: d.registryManager.address});
+        await managed.nonExistentManagerOp({from: d.initializationManager.address});
+
+        let r = await managed.initializationComplete();
+        expect(r).to.have.a.initializationCompleteEvent();
+
+        await expectRejected(managed.adminOp({from: d.initializationManager.address}), /sender is not an admin/);
+        await managed.adminOp({from: d.registryManager.address});
+        await expectRejected(managed.migrationManagerOp({from: d.initializationManager.address}), /sender is not the migration manager/);
+        await managed.migrationManagerOp({from: d.registryManager.address});
+        await expectRejected(managed.nonExistentManagerOp({from: d.initializationManager.address}), /sender is not the manager/);
+    });
+
+});

--- a/test/matchers.ts
+++ b/test/matchers.ts
@@ -245,6 +245,7 @@ declare global {
       stakeMigrationNotificationFailedEvent(data?: Partial<StakeMigrationNotificationFailedEvent>);
       migratedStakeEvent(data?: Partial<MigratedStakeEvent>);
       managerChangedEvent(data?: Partial<ManagerChangedEvent>);
+      initializationCompleteEvent(data?: {});
 
       withinContract(contract: Contract): Assertion;
     }

--- a/test/protocol-ownability.spec.ts
+++ b/test/protocol-ownability.spec.ts
@@ -31,7 +31,7 @@ describe('protocol-contract', async () => {
 
     const newAddr = d.newParticipant().address;
 
-    await expectRejected(d.protocol.setContractRegistry(newAddr, {from: d.functionalManager.address}), /caller is not the registryManager/);
+    await expectRejected(d.protocol.setContractRegistry(newAddr, {from: d.functionalManager.address}), /sender is not an admin/);
     await d.protocol.setContractRegistry(newAddr, {from: d.registryManager.address});
   });
 
@@ -39,7 +39,7 @@ describe('protocol-contract', async () => {
     const d = await Driver.new();
 
     const newOwner = d.newParticipant();
-    await expectRejected(d.protocol.transferRegistryManagement(newOwner.address, {from: d.functionalManager.address}), /caller is not the registryManager/);
+    await expectRejected(d.protocol.transferRegistryManagement(newOwner.address, {from: d.functionalManager.address}), /sender is not an admin/);
     await d.protocol.transferRegistryManagement(newOwner.address, {from: d.registryManager.address});
 
   });
@@ -51,14 +51,14 @@ describe('protocol-contract', async () => {
     await d.protocol.transferRegistryManagement(newManager.address, {from: d.registryManager.address});
 
     const newAddr = d.newParticipant().address;
-    await expectRejected(d.protocol.setContractRegistry(newAddr, {from: newManager.address}), /caller is not the registryManager/);
+    await expectRejected(d.protocol.setContractRegistry(newAddr, {from: newManager.address}), /sender is not an admin/);
     await d.protocol.setContractRegistry(newAddr, {from: d.registryManager.address});
 
     const notNewOwner = d.newParticipant();
     await expectRejected(d.protocol.claimRegistryManagement({from: notNewOwner.address}), /Caller is not the pending registryManager/);
 
     await d.protocol.claimRegistryManagement({from: newManager.address});
-    await expectRejected(d.protocol.setContractRegistry(newAddr, {from: d.registryManager.address}), /caller is not the registryManager/);
+    await expectRejected(d.protocol.setContractRegistry(newAddr, {from: d.registryManager.address}), /sender is not an admin/);
     await d.protocol.setContractRegistry(newAddr, {from: newManager.address});
   });
 

--- a/test/protocol-ownability.spec.ts
+++ b/test/protocol-ownability.spec.ts
@@ -39,7 +39,7 @@ describe('protocol-contract', async () => {
     const d = await Driver.new();
 
     const newOwner = d.newParticipant();
-    await expectRejected(d.protocol.transferRegistryManagement(newOwner.address, {from: d.functionalManager.address}), /sender is not an admin/);
+    await expectRejected(d.protocol.transferRegistryManagement(newOwner.address, {from: d.functionalManager.address}), /caller is not the registryManager/);
     await d.protocol.transferRegistryManagement(newOwner.address, {from: d.registryManager.address});
 
   });

--- a/test/staking-contract-handler.spec.ts
+++ b/test/staking-contract-handler.spec.ts
@@ -54,7 +54,7 @@ describe("staking-contract-handler", async () => {
         expect(r).to.have.a.stakeChangeBatchNotificationFailedEvent({stakeOwners: [p2.address]});
 
         // Stake migration - both staking contracts will notify, requires a complex setup
-        const newRegistry = await d.web3.deploy('ContractRegistry', [], null, d.session);
+        const newRegistry = await d.web3.deploy('ContractRegistry', [d.registryManager.address], null, d.session);
 
         const newHandler = await d.web3.deploy('StakingContractHandler', [newRegistry.address, d.registryManager.address], null, d.session);
         await newRegistry.setContract("stakingContractHandler", newHandler.address, true);
@@ -105,7 +105,7 @@ describe("staking-contract-handler", async () => {
         expect(r.gasUsed).to.be.greaterThan(5000000);
 
         // Stake migration - both staking contracts will notify, requires a complex setup
-        const newRegistry = await d.web3.deploy('ContractRegistry', [], null, d.session);
+        const newRegistry = await d.web3.deploy('ContractRegistry', [d.registryManager.address], null, d.session);
 
         const newHandler = await d.web3.deploy('StakingContractHandler', [newRegistry.address, d.registryManager.address], null, d.session);
         await newRegistry.setContract("stakingContractHandler", newHandler.address, true);

--- a/typings/base-contract.d.ts
+++ b/typings/base-contract.d.ts
@@ -18,4 +18,6 @@ export interface OwnedContract extends Contract {
     refreshContracts(): Promise<TransactionReceipt>;
 
     setContractRegistry(address: string, params?: TransactionConfig): Promise<TransactionReceipt>;
+
+    initializationComplete(): Promise<TransactionReceipt>;
 }

--- a/typings/contract-registry-contract.d.ts
+++ b/typings/contract-registry-contract.d.ts
@@ -9,6 +9,11 @@ export interface ContractRegistryContract extends OwnedContract {
 
   setManager(role: string, manager: string, params?: TransactionConfig): Promise<TransactionReceipt>;
   getManager(role: string): Promise<string>;
+
+  getManagedContracts(): Promise<string[]>;
+
+  lockContracts(params?: TransactionConfig): Promise<TransactionReceipt>;
+  unlockContracts(params?: TransactionConfig): Promise<TransactionReceipt>;
 }
 
 export interface ContractAddressUpdatedEvent {


### PR DESCRIPTION
Added the initializable pattern - the initialization manager has root access until initialization is complete
All managed contracts now inherit from a single contract - `ManagedContract`