### PR TITLE
gas savings for importDelegations

### DIFF
--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -163,7 +163,8 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ManagedContract {
 		// update totals
 		uncappedStakes[to] = uncappedStakes[to].add(uncappedStakesDelta);
 
-		if (stakeOwnersData[to].delegation == address(0) || stakeOwnersData[to].delegation == to) {
+		DelegateStatus memory delegateStatus = getDelegateStatus(to);
+		if (delegateStatus.isSelfDelegating) {
 			newTotalDelegatedStake = newTotalDelegatedStake.add(uncappedStakesDelta);
 		}
 		totalDelegatedStake = newTotalDelegatedStake;
@@ -175,7 +176,6 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ManagedContract {
 			emit Delegated(from[i], to);
 		}
 
-		DelegateStatus memory delegateStatus = getDelegateStatus(to);
 		emit DelegatedStakeChanged(
 			to,
 			delegateStatus.selfDelegatedStake,

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -143,7 +143,7 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ManagedContract {
 			require(data.delegation == address(0), "import allowed only for uninitialized accounts. existing delegation detected");
 			require(data.stake == 0 , "import allowed only for uninitialized accounts. existing stake detected");
 
-			if (to != from[i]) {
+			if (to != from[i]) { // from[i] stops being self delegating. any uncappedStakes it has now stops being counted towards totalDelegatedStake
 				newTotalDelegatedStake = newTotalDelegatedStake.sub(uncappedStakes[from[i]]);
 			}
 

--- a/contracts/Delegations.sol
+++ b/contracts/Delegations.sol
@@ -132,6 +132,8 @@ contract Delegations is IDelegations, IStakeChangeNotifier, ManagedContract {
 	}
 
 	function importDelegations(address[] calldata from, address to, bool refreshStakeNotification) external onlyMigrationManager onlyDuringDelegationImport {
+		require(to != address(0), "to must be a non zero address");
+		require(from.length > 0, "from array must contain at least one address");
 
 		uint256 uncappedStakesDelta = 0;
 		StakeOwnerData memory data;

--- a/contracts/spec_interfaces/IDelegation.sol
+++ b/contracts/spec_interfaces/IDelegation.sol
@@ -29,10 +29,10 @@ interface IDelegations /* is IStakeChangeNotifier */ {
     /// @dev Updates the address calldata of the contract registry
 	function setContractRegistry(IContractRegistry _contractRegistry) external /* onlyMigrationManager */;
 
-	function importDelegations(address[] calldata from, address[] calldata to, bool _refreshStakeNotification) external /* onlyMigrationManager onlyDuringDelegationImport */;
+	function importDelegations(address[] calldata from, address to, bool _refreshStakeNotification) external /* onlyMigrationManager onlyDuringDelegationImport */;
 	function finalizeDelegationImport() external /* onlyMigrationManager onlyDuringDelegationImport */;
 
-	event DelegationsImported(address[] from, address[] to, bool notifiedElections);
+	event DelegationsImported(address[] from, address to, bool notifiedElections);
 	event DelegationImportFinalized();
 
 	/*

--- a/test/delegations.spec.ts
+++ b/test/delegations.spec.ts
@@ -305,9 +305,7 @@ describe('delegations-contract', async () => {
         return async () => {
             const d = await Driver.new();
 
-            // setup a throwaway contract to prevent staking notifications from reaching the real Delegations contract
-            const notificationsSwallower = await d.web3.deploy("Delegations", [d.contractRegistry.address, d.registryAdmin.address], null, d.session);
-            await d.contractRegistry.setContract("delegations", notificationsSwallower.address, true, {from: d.registryAdmin.address});
+            await d.stakingContractHandler.setNotifyDelegations(false, {from: d.migrationManager.address});
 
             const d1 = d.newParticipant();
             await d1.stake(100);
@@ -318,8 +316,7 @@ describe('delegations-contract', async () => {
             const d3 = d.newParticipant();
             await d3.stake(300);
 
-            // restore the real Delegations contract
-            await d.contractRegistry.setContract("delegations", d.delegations.address, true, {from: d.registryAdmin.address});
+            await d.stakingContractHandler.setNotifyDelegations(true, {from: d.migrationManager.address});
 
             const {v: v1} = await d.newGuardian(100, false, false, true);
             const {v: v2} = await d.newGuardian(100, false, false, true);
@@ -391,9 +388,7 @@ describe('delegations-contract', async () => {
     it('tracks uncappedStakes and totalDelegateStakes correctly on importDelegations', async () => {
         const d = await Driver.new();
 
-        // setup a throwaway contract to prevent staking notifications from reaching the real Delegations contract
-        const notificationsSwallower = await d.web3.deploy("Delegations", [d.contractRegistry.address, d.registryAdmin.address], null, d.session);
-        await d.contractRegistry.setContract("delegations", notificationsSwallower.address, true, {from: d.registryAdmin.address});
+        await d.stakingContractHandler.setNotifyDelegations(false, {from: d.migrationManager.address});
 
         const d1 = d.newParticipant();
         await d1.stake(100);
@@ -404,8 +399,7 @@ describe('delegations-contract', async () => {
         const d3 = d.newParticipant();
         await d3.stake(300);
 
-        // restore the real Delegations contract
-        await d.contractRegistry.setContract("delegations", d.delegations.address, true, {from: d.registryAdmin.address});
+        await d.stakingContractHandler.setNotifyDelegations(true, {from: d.migrationManager.address});
 
         await d.delegations.importDelegations([d1.address], d2.address, false, {from: d.migrationManager.address});
         expect(await d.delegations.getTotalDelegatedStake()).to.be.bignumber.equal(bn(100));

--- a/test/gas-scenarios.spec.ts
+++ b/test/gas-scenarios.spec.ts
@@ -382,18 +382,19 @@ describe('gas usage scenarios', async () => {
     it("imports 50 delegations, unregistered guardians", async () => {
         const d = await Driver.new();
 
-        const delegations = _.range(50).map(() => [d.newParticipant(), d.newParticipant()]);
+        const delegate = d.newParticipant();
+        const delegations = _.range(50).map(() => d.newParticipant());
         await Promise.all(delegations.map(d => d[0].stake(100)));
 
         d.resetGasRecording();
         let r = await d.delegations.importDelegations(
-            delegations.map(d => d[0].address),
-            delegations.map(d => d[1].address),
+            delegations.map(d => d.address),
+            delegate.address,
             false
         , {from: d.migrationManager.address});
         expect(r).to.have.a.delegationsImportedEvent({
-            from: delegations.map(d => d[0].address),
-            to: delegations.map(d => d[1].address)
+            from: delegations.map(d => d.address),
+            to: delegations.map(delegate.address)
         });
 
         d.logGasUsageSummary("import 50 delegations, unregistered guardians", [d.migrationManager]);

--- a/typings/delegations-contract.d.ts
+++ b/typings/delegations-contract.d.ts
@@ -19,6 +19,7 @@ export interface DelegationsContract extends OwnedContract {
   getOwnStake(address: string): Promise<BN>;
   getSelfDelegatedStake(address: string): Promise<BN>;
   getTotalDelegatedStake(): Promise<BN>;
+  uncappedStakes(address: string): Promise<BN>;
 }
 
 export interface DelegatedEvent {

--- a/typings/delegations-contract.d.ts
+++ b/typings/delegations-contract.d.ts
@@ -7,7 +7,7 @@ export interface DelegationsContract extends OwnedContract {
   stakeChange(stakeOwner: string, amount: number, sign: boolean, updatedStake: number, params?: TransactionConfig): Promise<TransactionReceipt>;
   stakeChangeBatch(stakeOwners: string[], amounts: number[], signs: boolean[], updatedStakes: number[], params?: TransactionConfig) : Promise<TransactionReceipt>;
   delegate(to: string, params?: TransactionConfig): Promise<TransactionReceipt>;
-  importDelegations(from: string[], to: string[], notify: boolean, params?: TransactionConfig): Promise<TransactionReceipt>;
+  importDelegations(from: string[], to: string, notify: boolean, params?: TransactionConfig): Promise<TransactionReceipt>;
   finalizeDelegationImport(params?: TransactionConfig): Promise<TransactionReceipt>;
   setContractRegistry(contractRegistry: string, params?: TransactionConfig): Promise<TransactionReceipt>;
   refreshStake(addr: string, params?: TransactionConfig): Promise<TransactionReceipt>;
@@ -36,7 +36,7 @@ export interface DelegatedStakeChangedEvent {
 
 export interface DelegationsImportedEvent {
   from: string[];
-  to: string[];
+  to: string;
   notified: boolean;
 }
 


### PR DESCRIPTION
implemented importDelegations with gas efficiency in mind:

1. changed method signature
1. new restrictions on initial state for import to succeed. delegators must be uninitialized.

Please notice - we could allow importing delegation for users with explicit self delegation. The current implementation requires that their delegation will be `0`, but the solution also holds for the case where their delegation is explicitly self delegation.