### PR TITLE
PROTOCOL_WALLET: safeMath, require startTime not in the past, block.timestamp instead of now

### DIFF
--- a/contracts/FeesWallet.sol
+++ b/contracts/FeesWallet.sol
@@ -23,7 +23,7 @@ contract FeesWallet is IFeesWallet, ManagedContract {
 
     constructor(IContractRegistry _contractRegistry, address _registryAdmin, IERC20 _token) ManagedContract(_contractRegistry, _registryAdmin) public {
         token = _token;
-        lastCollectedAt = now;
+        lastCollectedAt = block.timestamp;
     }
 
     modifier onlyRewardsContract() {


### PR DESCRIPTION
fixes #282 