### PR TITLE
REWARDS: add info to reward events, totalAwarded 

### DIFF
--- a/contracts/FeesAndBootstrapRewards.sol
+++ b/contracts/FeesAndBootstrapRewards.sol
@@ -139,7 +139,8 @@ contract FeesAndBootstrapRewards is IFeesAndBootstrapRewards, ManagedContract {
         uint256 withdrawnBootstrap,
         bool certified
     ) {
-        (FeesAndBootstrap memory guardianFeesAndBootstrap, bool certified) = getGuardianFeesAndBootstrap(guardian, block.timestamp);
+        FeesAndBootstrap memory guardianFeesAndBootstrap;
+        (guardianFeesAndBootstrap, certified) = getGuardianFeesAndBootstrap(guardian, block.timestamp);
         return (
             guardianFeesAndBootstrap.feeBalance,
             guardianFeesAndBootstrap.lastFeesPerMember,

--- a/contracts/FeesAndBootstrapRewards.sol
+++ b/contracts/FeesAndBootstrapRewards.sol
@@ -97,8 +97,9 @@ contract FeesAndBootstrapRewards is IFeesAndBootstrapRewards, ManagedContract {
         updateGuardianFeesAndBootstrap(guardian);
         uint256 amount = feesAndBootstrap[guardian].bootstrapBalance;
         feesAndBootstrap[guardian].bootstrapBalance = 0;
-        feesAndBootstrap[guardian].withdrawnBootstrap = feesAndBootstrap[guardian].withdrawnBootstrap.add(amount);
-        emit BootstrapRewardsWithdrawn(guardian, amount, feesAndBootstrap[guardian].withdrawnBootstrap);
+        uint96 withdrawnBootstrap = feesAndBootstrap[guardian].withdrawnBootstrap.add(amount);
+        feesAndBootstrap[guardian].withdrawnBootstrap = withdrawnBootstrap;
+        emit BootstrapRewardsWithdrawn(guardian, amount, withdrawnBootstrap);
 
         require(bootstrapToken.transfer(guardian, amount), "Rewards::withdrawBootstrapFunds - insufficient funds");
     }
@@ -108,9 +109,10 @@ contract FeesAndBootstrapRewards is IFeesAndBootstrapRewards, ManagedContract {
 
         uint256 amount = feesAndBootstrap[guardian].feeBalance;
         feesAndBootstrap[guardian].feeBalance = 0;
-        feesAndBootstrap[guardian].withdrawnFees = feesAndBootstrap[guardian].withdrawnFees.add(amount);
+        uint96 withdrawnFees = feesAndBootstrap[guardian].withdrawnFees.add(amount);
+        feesAndBootstrap[guardian].withdrawnFees = withdrawnFees;
 
-        emit FeesWithdrawn(guardian, amount, feesAndBootstrap[guardian].withdrawnFees);
+        emit FeesWithdrawn(guardian, amount, withdrawnFees);
         require(feesToken.transfer(guardian, amount), "Rewards::withdrawFees - insufficient funds");
     }
 

--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -418,7 +418,7 @@ contract StakingRewards is IStakingRewards, ManagedContract {
         uint256 delegatorRewardsPerTokenDelta;
         (guardianStakingRewards, guardianStakingRewardsAdded, stakingRewardsPerWeightDelta, delegatorRewardsPerTokenDelta) = _getGuardianStakingRewards(guardian, inCommittee, inCommitteeAfter, guardianWeight, guardianDelegatedStake, _stakingRewardsState, _settings);
         guardiansStakingRewards[guardian] = guardianStakingRewards;
-        emit GuardianStakingRewardsAssigned(guardian, guardianStakingRewardsAdded, guardianStakingRewards.claimed.add(guardianStakingRewards.balance), guardianStakingRewards.delegatorRewardsPerToken, _stakingRewardsState.stakingRewardsPerWeight, stakingRewardsPerWeightDelta, delegatorRewardsPerTokenDelta);
+        emit GuardianStakingRewardsAssigned(guardian, guardianStakingRewardsAdded, guardianStakingRewards.claimed.add(guardianStakingRewards.balance), guardianStakingRewards.delegatorRewardsPerToken, delegatorRewardsPerTokenDelta, _stakingRewardsState.stakingRewardsPerWeight, stakingRewardsPerWeightDelta);
     }
 
     function updateGuardianStakingRewards(address guardian, StakingRewardsState memory _stakingRewardsState, Settings memory _settings) private returns (GuardianStakingRewards memory guardianStakingRewards) {

--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -127,7 +127,7 @@ contract StakingRewards is IStakingRewards, ManagedContract {
 
     function getStakingRewardsBalance(address addr) external override view returns (uint256 delegatorStakingRewardsBalance, uint256 guardianStakingRewardsBalance) {
         (DelegatorStakingRewards memory delegatorStakingRewards,,) = getDelegatorStakingRewards(addr, block.timestamp);
-        GuardianStakingRewards memory guardianStakingRewards = getGuardianStakingRewards(addr, block.timestamp); // TODO consider removing, data in state must be up to date at this point
+        (GuardianStakingRewards memory guardianStakingRewards,,) = getGuardianStakingRewards(addr, block.timestamp); // TODO consider removing, data in state must be up to date at this point
         return (delegatorStakingRewards.balance, guardianStakingRewards.balance);
     }
 
@@ -158,27 +158,29 @@ contract StakingRewards is IStakingRewards, ManagedContract {
         uint256 balance,
         uint256 claimed,
         uint256 delegatorRewardsPerToken,
-        uint256 lastStakingRewardsPerWeight
+        uint256 delegatorRewardsPerTokenDelta,
+        uint256 lastStakingRewardsPerWeight,
+        uint256 stakingRewardsPerWeightDelta
     ) {
-        GuardianStakingRewards memory rewards = getGuardianStakingRewards(guardian, block.timestamp);
-        return (rewards.balance, rewards.claimed, rewards.delegatorRewardsPerToken, rewards.lastStakingRewardsPerWeight);
+        (GuardianStakingRewards memory rewards, uint256 _stakingRewardsPerWeightDelta, uint256 _delegatorRewardsPerTokenDelta) = getGuardianStakingRewards(guardian, block.timestamp);
+        return (rewards.balance, rewards.claimed, rewards.delegatorRewardsPerToken, _delegatorRewardsPerTokenDelta, rewards.lastStakingRewardsPerWeight, _stakingRewardsPerWeightDelta);
     }
 
     function getDelegatorStakingRewardsData(address delegator) external override view returns (
         uint256 balance,
         uint256 claimed,
-        uint256 lastDelegatorRewardsPerToken,
         address guardian,
-        uint256 stake
+        uint256 lastDelegatorRewardsPerToken,
+        uint256 delegatorRewardsPerTokenDelta
     ) {
-        (DelegatorStakingRewards memory rewards, address _guardian, uint256 _stake) = getDelegatorStakingRewards(delegator, block.timestamp);
-        return (rewards.balance, rewards.claimed, rewards.lastDelegatorRewardsPerToken, _guardian, _stake);
+        (DelegatorStakingRewards memory rewards, address _guardian, uint256 _delegatorRewardsPerTokenDelta) = getDelegatorStakingRewards(delegator, block.timestamp);
+        return (rewards.balance, rewards.claimed, _guardian, rewards.lastDelegatorRewardsPerToken, _delegatorRewardsPerTokenDelta);
     }
 
     function estimateFutureRewards(address addr, uint256 duration) external override view returns (uint256 estimatedDelegatorStakingRewards, uint256 estimatedGuardianStakingRewards) {
-        GuardianStakingRewards memory guardianRewardsNow = getGuardianStakingRewards(addr, block.timestamp);
+        (GuardianStakingRewards memory guardianRewardsNow,,) = getGuardianStakingRewards(addr, block.timestamp);
         (DelegatorStakingRewards memory delegatorRewardsNow,,) = getDelegatorStakingRewards(addr, block.timestamp);
-        GuardianStakingRewards memory guardianRewardsFuture = getGuardianStakingRewards(addr, block.timestamp.add(duration));
+        (GuardianStakingRewards memory guardianRewardsFuture,,) = getGuardianStakingRewards(addr, block.timestamp.add(duration));
         (DelegatorStakingRewards memory delegatorRewardsFuture,,) = getDelegatorStakingRewards(addr, block.timestamp.add(duration));
 
         estimatedDelegatorStakingRewards = delegatorRewardsFuture.balance.sub(delegatorRewardsNow.balance);
@@ -334,12 +336,12 @@ contract StakingRewards is IStakingRewards, ManagedContract {
         return totalCommitteeWeight == 0 ? 0 : Math.min(uint(_settings.annualRateInPercentMille), uint256(_settings.annualCap).mul(PERCENT_MILLIE_BASE).div(totalCommitteeWeight));
     }
 
-    function calcStakingRewardPerWeightDelta(uint256 totalCommitteeWeight, uint duration, Settings memory _settings) private pure returns (uint256 stakingRewardsPerTokenDelta) {
-        stakingRewardsPerTokenDelta = 0;
+    function calcStakingRewardPerWeightDelta(uint256 totalCommitteeWeight, uint duration, Settings memory _settings) private pure returns (uint256 stakingRewardsPerWeightDelta) {
+        stakingRewardsPerWeightDelta = 0;
 
         if (totalCommitteeWeight > 0) {
             uint annualRateInPercentMille = _getAnnualRate(totalCommitteeWeight, _settings);
-            stakingRewardsPerTokenDelta = annualRateInPercentMille.mul(TOKEN_BASE).mul(duration).div(PERCENT_MILLIE_BASE.mul(365 days));
+            stakingRewardsPerWeightDelta = annualRateInPercentMille.mul(TOKEN_BASE).mul(duration).div(PERCENT_MILLIE_BASE.mul(365 days));
         }
     }
 
@@ -372,17 +374,16 @@ contract StakingRewards is IStakingRewards, ManagedContract {
 
     // Guardian state
 
-    function _getGuardianStakingRewards(address guardian, bool inCommittee, bool inCommitteeAfter, uint256 guardianWeight, uint256 guardianDelegatedStake, StakingRewardsState memory _stakingRewardsState, Settings memory _settings) private view returns (GuardianStakingRewards memory guardianStakingRewards, uint256 rewardsAdded) {
+    function _getGuardianStakingRewards(address guardian, bool inCommittee, bool inCommitteeAfter, uint256 guardianWeight, uint256 guardianDelegatedStake, StakingRewardsState memory _stakingRewardsState, Settings memory _settings) private view returns (GuardianStakingRewards memory guardianStakingRewards, uint256 rewardsAdded, uint256 stakingRewardsPerWeightDelta, uint256 delegatorRewardsPerTokenDelta) {
         guardianStakingRewards = guardiansStakingRewards[guardian];
 
         if (inCommittee) {
-            uint256 totalRewards = uint256(_stakingRewardsState.stakingRewardsPerWeight)
-                .sub(guardianStakingRewards.lastStakingRewardsPerWeight)
-                .mul(guardianWeight);
+            stakingRewardsPerWeightDelta = uint256(_stakingRewardsState.stakingRewardsPerWeight).sub(guardianStakingRewards.lastStakingRewardsPerWeight);
+            uint256 totalRewards = stakingRewardsPerWeightDelta.mul(guardianWeight);
 
             uint256 delegatorRewardsRatioPercentMille = _getGuardianDelegatorsStakingRewardsPercentMille(guardian, _settings);
 
-            uint256 delegatorRewardsPerTokenDelta = guardianDelegatedStake == 0 ? 0 : totalRewards
+            delegatorRewardsPerTokenDelta = guardianDelegatedStake == 0 ? 0 : totalRewards
                 .div(guardianDelegatedStake)
                 .mul(delegatorRewardsRatioPercentMille)
                 .div(PERCENT_MILLIE_BASE);
@@ -401,21 +402,23 @@ contract StakingRewards is IStakingRewards, ManagedContract {
         guardianStakingRewards.lastStakingRewardsPerWeight = inCommitteeAfter ? _stakingRewardsState.stakingRewardsPerWeight : 0;
     }
 
-    function getGuardianStakingRewards(address guardian, uint256 currentTime) private view returns (GuardianStakingRewards memory guardianStakingRewards) {
+    function getGuardianStakingRewards(address guardian, uint256 currentTime) private view returns (GuardianStakingRewards memory guardianStakingRewards, uint256 stakingRewardsPerWeightDelta, uint256 delegatorRewardsPerTokenDelta) {
         Settings memory _settings = settings;
 
         (bool inCommittee, uint256 guardianWeight, ,uint256 totalCommitteeWeight) = committeeContract.getMemberInfo(guardian);
         uint256 guardianDelegatedStake = delegationsContract.getDelegatedStake(guardian);
 
         (StakingRewardsState memory _stakingRewardsState,) = _getStakingRewardsState(totalCommitteeWeight, currentTime, _settings);
-        (guardianStakingRewards,) = _getGuardianStakingRewards(guardian, inCommittee, inCommittee, guardianWeight, guardianDelegatedStake, _stakingRewardsState, _settings);
+        (guardianStakingRewards,,stakingRewardsPerWeightDelta,delegatorRewardsPerTokenDelta) = _getGuardianStakingRewards(guardian, inCommittee, inCommittee, guardianWeight, guardianDelegatedStake, _stakingRewardsState, _settings);
     }
 
     function _updateGuardianStakingRewards(address guardian, bool inCommittee, bool inCommitteeAfter, uint256 guardianWeight, uint256 guardianDelegatedStake, StakingRewardsState memory _stakingRewardsState, Settings memory _settings) private returns (GuardianStakingRewards memory guardianStakingRewards) {
         uint256 guardianStakingRewardsAdded;
-        (guardianStakingRewards, guardianStakingRewardsAdded) = _getGuardianStakingRewards(guardian, inCommittee, inCommitteeAfter, guardianWeight, guardianDelegatedStake, _stakingRewardsState, _settings);
+        uint256 stakingRewardsPerWeightDelta;
+        uint256 delegatorRewardsPerTokenDelta;
+        (guardianStakingRewards, guardianStakingRewardsAdded, stakingRewardsPerWeightDelta, delegatorRewardsPerTokenDelta) = _getGuardianStakingRewards(guardian, inCommittee, inCommitteeAfter, guardianWeight, guardianDelegatedStake, _stakingRewardsState, _settings);
         guardiansStakingRewards[guardian] = guardianStakingRewards;
-        emit GuardianStakingRewardsAssigned(guardian, guardianStakingRewardsAdded, guardianStakingRewards.claimed.add(guardianStakingRewards.balance), guardianStakingRewards.delegatorRewardsPerToken, _stakingRewardsState.stakingRewardsPerWeight);
+        emit GuardianStakingRewardsAssigned(guardian, guardianStakingRewardsAdded, guardianStakingRewards.claimed.add(guardianStakingRewards.balance), guardianStakingRewards.delegatorRewardsPerToken, _stakingRewardsState.stakingRewardsPerWeight, stakingRewardsPerWeightDelta, delegatorRewardsPerTokenDelta);
     }
 
     function updateGuardianStakingRewards(address guardian, StakingRewardsState memory _stakingRewardsState, Settings memory _settings) private returns (GuardianStakingRewards memory guardianStakingRewards) {
@@ -425,32 +428,35 @@ contract StakingRewards is IStakingRewards, ManagedContract {
 
     // Delegator state
 
-    function _getDelegatorStakingRewards(address delegator, uint256 delegatorStake, GuardianStakingRewards memory guardianStakingRewards) private view returns (DelegatorStakingRewards memory delegatorStakingRewards, uint256 delegatorRewardsAdded) {
+    function _getDelegatorStakingRewards(address delegator, uint256 delegatorStake, GuardianStakingRewards memory guardianStakingRewards) private view returns (DelegatorStakingRewards memory delegatorStakingRewards, uint256 delegatorRewardsAdded, uint256 delegatorRewardsPerTokenDelta) {
         delegatorStakingRewards = delegatorsStakingRewards[delegator];
 
-        delegatorRewardsAdded = uint256(guardianStakingRewards.delegatorRewardsPerToken)
-                .sub(delegatorStakingRewards.lastDelegatorRewardsPerToken)
-                .mul(delegatorStake)
-                .div(TOKEN_BASE);
+        delegatorRewardsPerTokenDelta = uint256(guardianStakingRewards.delegatorRewardsPerToken)
+            .sub(delegatorStakingRewards.lastDelegatorRewardsPerToken);
+        delegatorRewardsAdded = delegatorRewardsPerTokenDelta
+            .mul(delegatorStake)
+            .div(TOKEN_BASE);
 
         delegatorStakingRewards.balance = delegatorStakingRewards.balance.add(delegatorRewardsAdded);
         delegatorStakingRewards.lastDelegatorRewardsPerToken = guardianStakingRewards.delegatorRewardsPerToken;
     }
 
-    function getDelegatorStakingRewards(address delegator, uint256 currentTime) private view returns (DelegatorStakingRewards memory delegatorStakingRewards, address guardian, uint256 delegatorStake) {
+    function getDelegatorStakingRewards(address delegator, uint256 currentTime) private view returns (DelegatorStakingRewards memory delegatorStakingRewards, address guardian, uint256 delegatorStakingRewardsPerTokenDelta) {
+        uint256 delegatorStake;
         (guardian, delegatorStake) = delegationsContract.getDelegationInfo(delegator);
-        GuardianStakingRewards memory guardianStakingRewards = getGuardianStakingRewards(guardian, currentTime);
+        (GuardianStakingRewards memory guardianStakingRewards,,) = getGuardianStakingRewards(guardian, currentTime);
 
-        (delegatorStakingRewards,) = _getDelegatorStakingRewards(delegator, delegatorStake, guardianStakingRewards);
+        (delegatorStakingRewards,,delegatorStakingRewardsPerTokenDelta) = _getDelegatorStakingRewards(delegator, delegatorStake, guardianStakingRewards);
     }
 
     function _updateDelegatorStakingRewards(address delegator, uint256 delegatorStake, address guardian, GuardianStakingRewards memory guardianStakingRewards) private {
         uint256 delegatorStakingRewardsAdded;
+        uint256 delegatorRewardsPerTokenDelta;
         DelegatorStakingRewards memory delegatorStakingRewards;
-        (delegatorStakingRewards, delegatorStakingRewardsAdded) = _getDelegatorStakingRewards(delegator, delegatorStake, guardianStakingRewards);
+        (delegatorStakingRewards, delegatorStakingRewardsAdded, delegatorRewardsPerTokenDelta) = _getDelegatorStakingRewards(delegator, delegatorStake, guardianStakingRewards);
         delegatorsStakingRewards[delegator] = delegatorStakingRewards;
 
-        emit DelegatorStakingRewardsAssigned(delegator, delegatorStakingRewardsAdded, delegatorStakingRewards.claimed.add(delegatorStakingRewards.balance), guardian, delegatorStake, guardianStakingRewards.delegatorRewardsPerToken);
+        emit DelegatorStakingRewardsAssigned(delegator, delegatorStakingRewardsAdded, delegatorStakingRewards.claimed.add(delegatorStakingRewards.balance), guardian, guardianStakingRewards.delegatorRewardsPerToken, delegatorRewardsPerTokenDelta);
     }
 
     function updateDelegatorStakingRewards(address delegator) private {

--- a/contracts/spec_interfaces/IFeesAndBootstrapRewards.sol
+++ b/contracts/spec_interfaces/IFeesAndBootstrapRewards.sol
@@ -50,7 +50,8 @@ interface IFeesAndBootstrapRewards {
         uint256 bootstrapBalance,
         uint256 lastBootstrapPerMember,
         uint256 withdrawnFees,
-        uint256 withdrawnBootstrap
+        uint256 withdrawnBootstrap,
+        bool certified
     );
 
     /*

--- a/contracts/spec_interfaces/IFeesAndBootstrapRewards.sol
+++ b/contracts/spec_interfaces/IFeesAndBootstrapRewards.sol
@@ -5,11 +5,11 @@ pragma solidity 0.6.12;
 /// @title Rewards contract interface
 interface IFeesAndBootstrapRewards {
     event FeesAllocated(uint256 allocatedGeneralFees, uint256 generalFeesPerMember, uint256 allocatedCertifiedFees, uint256 certifiedFeesPerMember);
-    event FeesAssigned(address indexed guardian, uint256 amount);
-    event FeesWithdrawn(address indexed guardian, uint256 amount);
+    event FeesAssigned(address indexed guardian, uint256 amount, uint256 totalAwarded, bool certification, uint256 feesPerMember);
+    event FeesWithdrawn(address indexed guardian, uint256 amount, uint256 totalWithdrawn);
     event BootstrapRewardsAllocated(uint256 allocatedGeneralBootstrapRewards, uint256 generalBootstrapRewardsPerMember, uint256 allocatedCertifiedBootstrapRewards, uint256 certifiedBootstrapRewardsPerMember);
-    event BootstrapRewardsAssigned(address indexed guardian, uint256 amount);
-    event BootstrapRewardsWithdrawn(address indexed guardian, uint256 amount);
+    event BootstrapRewardsAssigned(address indexed guardian, uint256 amount, uint256 totalAwarded, bool certification, uint256 bootstrapPerMember);
+    event BootstrapRewardsWithdrawn(address indexed guardian, uint256 amount, uint256 totalWithdrawn);
 
     /*
     * External functions
@@ -48,7 +48,9 @@ interface IFeesAndBootstrapRewards {
         uint256 feeBalance,
         uint256 lastFeesPerMember,
         uint256 bootstrapBalance,
-        uint256 lastBootstrapPerMember
+        uint256 lastBootstrapPerMember,
+        uint256 withdrawnFees,
+        uint256 withdrawnBootstrap
     );
 
     /*

--- a/contracts/spec_interfaces/IStakingRewards.sol
+++ b/contracts/spec_interfaces/IStakingRewards.sol
@@ -5,8 +5,8 @@ pragma solidity 0.6.12;
 /// @title Staking rewards contract interface
 interface IStakingRewards {
 
-    event DelegatorStakingRewardsAssigned(address indexed delegator, uint256 amount, uint256 totalAwarded, address guardian, uint256 stake, uint256 delegatorRewardsPerToken);
-    event GuardianStakingRewardsAssigned(address indexed guardian, uint256 amount, uint256 totalAwarded, uint256 delegatorRewardsPerToken, uint256 stakingRewardsPerWeight);
+    event DelegatorStakingRewardsAssigned(address indexed delegator, uint256 amount, uint256 totalAwarded, address guardian, uint256 delegatorRewardsPerToken, uint256 delegatorRewardsPerTokenDelta);
+    event GuardianStakingRewardsAssigned(address indexed guardian, uint256 amount, uint256 totalAwarded, uint256 delegatorRewardsPerToken, uint256 stakingRewardsPerWeight, uint256 stakingRewardsPerWeightDelta, uint256 delegatorRewardsPerTokenDelta);
     event StakingRewardsClaimed(address indexed addr, uint256 claimedDelegatorRewards, uint256 claimedGuardianRewards, uint256 totalClaimedDelegatorRewards, uint256 totalClaimedGuardianRewards);
     event StakingRewardsAllocated(uint256 allocatedRewards, uint256 stakingRewardsPerWeight);
     event GuardianDelegatorsStakingRewardsPercentMilleUpdated(address indexed guardian, uint256 delegatorsStakingRewardsPercentMille);
@@ -36,15 +36,17 @@ interface IStakingRewards {
         uint256 balance,
         uint256 claimed,
         uint256 delegatorRewardsPerToken,
-        uint256 lastStakingRewardsPerWeight
+        uint256 delegatorRewardsPerTokenDelta,
+        uint256 lastStakingRewardsPerWeight,
+        uint256 stakingRewardsPerWeightDelta
     );
 
     function getDelegatorStakingRewardsData(address delegator) external view returns (
         uint256 balance,
         uint256 claimed,
-        uint256 lastDelegatorRewardsPerToken,
         address guardian,
-        uint256 stake
+        uint256 lastDelegatorRewardsPerToken,
+        uint256 delegatorRewardsPerTokenDelta
     );
 
     function estimateFutureRewards(address addr, uint256 duration) external view returns (

--- a/contracts/spec_interfaces/IStakingRewards.sol
+++ b/contracts/spec_interfaces/IStakingRewards.sol
@@ -6,7 +6,7 @@ pragma solidity 0.6.12;
 interface IStakingRewards {
 
     event DelegatorStakingRewardsAssigned(address indexed delegator, uint256 amount, uint256 totalAwarded, address guardian, uint256 delegatorRewardsPerToken, uint256 delegatorRewardsPerTokenDelta);
-    event GuardianStakingRewardsAssigned(address indexed guardian, uint256 amount, uint256 totalAwarded, uint256 delegatorRewardsPerToken, uint256 stakingRewardsPerWeight, uint256 stakingRewardsPerWeightDelta, uint256 delegatorRewardsPerTokenDelta);
+    event GuardianStakingRewardsAssigned(address indexed guardian, uint256 amount, uint256 totalAwarded, uint256 delegatorRewardsPerToken, uint256 delegatorRewardsPerTokenDelta, uint256 stakingRewardsPerWeight, uint256 stakingRewardsPerWeightDelta);
     event StakingRewardsClaimed(address indexed addr, uint256 claimedDelegatorRewards, uint256 claimedGuardianRewards, uint256 totalClaimedDelegatorRewards, uint256 totalClaimedGuardianRewards);
     event StakingRewardsAllocated(uint256 allocatedRewards, uint256 stakingRewardsPerWeight);
     event GuardianDelegatorsStakingRewardsPercentMilleUpdated(address indexed guardian, uint256 delegatorsStakingRewardsPercentMille);

--- a/contracts/spec_interfaces/IStakingRewards.sol
+++ b/contracts/spec_interfaces/IStakingRewards.sol
@@ -5,7 +5,7 @@ pragma solidity 0.6.12;
 /// @title Staking rewards contract interface
 interface IStakingRewards {
 
-    event DelegatorStakingRewardsAssigned(address indexed delegator, uint256 amount, uint256 totalAwarded, address guardian, uint256 delegatorRewardsPerToken);
+    event DelegatorStakingRewardsAssigned(address indexed delegator, uint256 amount, uint256 totalAwarded, address guardian, uint256 stake, uint256 delegatorRewardsPerToken);
     event GuardianStakingRewardsAssigned(address indexed guardian, uint256 amount, uint256 totalAwarded, uint256 delegatorRewardsPerToken, uint256 stakingRewardsPerWeight);
     event StakingRewardsClaimed(address indexed addr, uint256 claimedDelegatorRewards, uint256 claimedGuardianRewards, uint256 totalClaimedDelegatorRewards, uint256 totalClaimedGuardianRewards);
     event StakingRewardsAllocated(uint256 allocatedRewards, uint256 stakingRewardsPerWeight);
@@ -42,7 +42,9 @@ interface IStakingRewards {
     function getDelegatorStakingRewardsData(address delegator) external view returns (
         uint256 balance,
         uint256 claimed,
-        uint256 lastDelegatorRewardsPerToken
+        uint256 lastDelegatorRewardsPerToken,
+        address guardian,
+        uint256 stake
     );
 
     function estimateFutureRewards(address addr, uint256 duration) external view returns (

--- a/test/rewards.spec.ts
+++ b/test/rewards.spec.ts
@@ -487,6 +487,10 @@ describe('rewards', async () => {
         expectApproxEq((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).feeBalance, expectedFees);
         expectApproxEq((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).withdrawnFees, expectedFees);
         expectApproxEq((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).lastFeesPerMember, expectedFees.mul(bn(2)));
+
+        expect((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).certified).to.be.false;
+        await c0.becomeCertified();
+        expect((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).certified).to.be.true;
     });
 
     // Staking rewards

--- a/test/rewards.spec.ts
+++ b/test/rewards.spec.ts
@@ -216,8 +216,20 @@ describe('rewards', async () => {
             allocatedCertifiedBootstrapRewards: bn(0),
             certifiedBootstrapRewardsPerMember: certifiedBootstrapForDuration(DURATION / 4),
         });
-        expect(r).to.have.a.approx().feesAssignedEvent({guardian: committee[0].address, amount: generalFeesForDuration(DURATION / 4, MAX_COMMITTEE)});
-        expect(r).to.have.a.approx().bootstrapRewardsAssignedEvent({guardian: committee[0].address, amount: generalBootstrapForDuration(DURATION / 4)});
+        expect(r).to.have.a.approx().feesAssignedEvent({
+            guardian: committee[0].address,
+            amount: generalFeesForDuration(DURATION / 4, MAX_COMMITTEE),
+            totalAwarded: generalFeesForDuration(DURATION / 4, MAX_COMMITTEE),
+            certification: false,
+            feesPerMember: generalFeesForDuration(DURATION / 4, MAX_COMMITTEE)
+        });
+        expect(r).to.have.a.approx().bootstrapRewardsAssignedEvent({
+            guardian: committee[0].address,
+            amount: generalBootstrapForDuration(DURATION / 4),
+            totalAwarded: generalBootstrapForDuration(DURATION / 4),
+            certification: false,
+            bootstrapPerMember: generalBootstrapForDuration(DURATION / 4)
+        });
 
         expectApproxEq(await committee[0].getFeeBalance(), generalFeesForDuration(DURATION / 4, MAX_COMMITTEE));
         expectApproxEq(await committee[0].getBootstrapBalance(), generalBootstrapForDuration(DURATION / 4));
@@ -449,6 +461,34 @@ describe('rewards', async () => {
         expectApproxEq((await d.feesAndBootstrapRewards.estimateFutureFeesAndBootstrapRewards(c0.address, PERIOD / 2)).estimatedBootstrapRewards, expectedBootstrap.div(bn(2)));
     });
 
+    it('returns fees and bootstrap data', async () => {
+        const {d, committee} = await fullCommittee([fromMilliOrbs(4000), fromMilliOrbs(3000), fromMilliOrbs(2000), fromMilliOrbs(1000)], 1);
+
+        const PERIOD = MONTH_IN_SECONDS * 2;
+
+        await evmIncreaseTimeForQueries(d.web3, PERIOD);
+
+        const c0 = committee[0];
+
+        const expectedFees = await generalFeesForDuration(PERIOD, MAX_COMMITTEE);
+        const expectedBootstrap = await generalBootstrapForDuration(PERIOD);
+
+        expect(expectedFees).to.be.bignumber.gt(bn(0));
+        expect(expectedBootstrap).to.be.bignumber.gt(bn(0));
+
+        await d.feesAndBootstrapRewards.withdrawFees(c0.address);
+        await d.feesAndBootstrapRewards.withdrawBootstrapFunds(c0.address);
+
+        await evmIncreaseTimeForQueries(d.web3, PERIOD);
+
+        expectApproxEq((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).bootstrapBalance, expectedBootstrap);
+        expectApproxEq((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).withdrawnBootstrap, expectedBootstrap);
+        expectApproxEq((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).lastBootstrapPerMember, expectedBootstrap.mul(bn(2)));
+        expectApproxEq((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).feeBalance, expectedFees);
+        expectApproxEq((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).withdrawnFees, expectedFees);
+        expectApproxEq((await d.feesAndBootstrapRewards.getFeesAndBootstrapData(c0.address)).lastFeesPerMember, expectedFees.mul(bn(2)));
+    });
+
     // Staking rewards
 
     it('successfully claims 0 staking rewards ', async () => {
@@ -659,6 +699,7 @@ describe('rewards', async () => {
             amount: bn((await d.stakingRewards.delegatorsStakingRewards(d0.address)).balance),
             totalAwarded: bn((await d.stakingRewards.delegatorsStakingRewards(d0.address)).balance),
             guardian: c0.address,
+            stake: fromMilliOrbs(1000),
             delegatorRewardsPerToken: bn((await d.stakingRewards.guardiansStakingRewards(c0.address)).delegatorRewardsPerToken),
         });
         
@@ -729,6 +770,49 @@ describe('rewards', async () => {
 
         expectApproxEq((await d.stakingRewards.getStakingRewardsBalance(c0.address)).delegatorStakingRewardsBalance, expectedDelegatorRewards);
         expectApproxEq((await d.stakingRewards.getStakingRewardsBalance(c0.address)).guardianStakingRewardsBalance, expectedGuardianRewards);
+    });
+
+    it('properly returns guardian and delegator rewards data', async () => {
+        const {d, committee} = await fullCommittee([fromMilliOrbs(4000), fromMilliOrbs(3000), fromMilliOrbs(2000), fromMilliOrbs(1000)], 1);
+
+        const c0 = committee[0];
+
+        const delegator = d.newParticipant();
+        await delegator.stake(fromMilliOrbs(1000));
+        await delegator.delegate(c0);
+
+        const PERIOD = MONTH_IN_SECONDS * 5;
+
+        await evmIncreaseTimeForQueries(d.web3, PERIOD);
+
+        const c0_expectedDelegatorRewards = (await stakingRewardsForDuration(d, PERIOD, c0, c0)).delegatorRewards;
+        const c0_expectedGuardianRewards = (await stakingRewardsForDuration(d, PERIOD, c0, c0)).guardianRewards.sub(c0_expectedDelegatorRewards);
+
+        const delegator_expectedDelegatorRewards = (await stakingRewardsForDuration(d, PERIOD, delegator, c0)).delegatorRewards;
+
+        expect(c0_expectedDelegatorRewards).to.be.bignumber.gt(bn(0));
+        expect(c0_expectedGuardianRewards).to.be.bignumber.gt(bn(0));
+        expect(delegator_expectedDelegatorRewards).to.be.bignumber.gt(bn(0));
+
+        await d.stakingRewards.claimStakingRewards(c0.address);
+        await c0.unstake(c0_expectedDelegatorRewards.add(c0_expectedGuardianRewards));
+
+        await evmIncreaseTimeForQueries(d.web3, PERIOD);
+
+        expectApproxEq(bn((await d.stakingRewards.getGuardianStakingRewardsData(c0.address)).claimed), c0_expectedGuardianRewards)
+        expectApproxEq(bn((await d.stakingRewards.getGuardianStakingRewardsData(c0.address)).balance), c0_expectedGuardianRewards)
+        expectApproxEq(bn((await d.stakingRewards.getGuardianStakingRewardsData(c0.address)).lastStakingRewardsPerWeight), (await d.stakingRewards.getStakingRewardsState()).stakingRewardsPerWeight);
+        expectApproxEq(bn((await d.stakingRewards.getGuardianStakingRewardsData(c0.address)).delegatorRewardsPerToken), c0_expectedDelegatorRewards.mul(bn(2)).mul(bn(10).pow(bn(18))).div(fromMilliOrbs(4000)));
+
+        expectApproxEq(bn((await d.stakingRewards.getDelegatorStakingRewardsData(c0.address)).balance), c0_expectedDelegatorRewards);
+        expectApproxEq(bn((await d.stakingRewards.getDelegatorStakingRewardsData(c0.address)).claimed), c0_expectedDelegatorRewards);
+        expect((await d.stakingRewards.getDelegatorStakingRewardsData(c0.address)).guardian).to.eq(c0.address);
+        expectApproxEq(bn((await d.stakingRewards.getDelegatorStakingRewardsData(c0.address)).stake), fromMilliOrbs(4000));
+
+        expectApproxEq(bn((await d.stakingRewards.getDelegatorStakingRewardsData(delegator.address)).balance), delegator_expectedDelegatorRewards.mul(bn(2)));
+        expectApproxEq(bn((await d.stakingRewards.getDelegatorStakingRewardsData(delegator.address)).claimed), bn(0));
+        expect((await d.stakingRewards.getDelegatorStakingRewardsData(delegator.address)).guardian).to.eq(c0.address);
+        expect(bn((await d.stakingRewards.getDelegatorStakingRewardsData(delegator.address)).stake)).to.bignumber.eq(fromMilliOrbs(1000));
     });
 
     it('properly estimates guardian and delegator future rewards', async () => {

--- a/typings/fees-and-bootstrap-rewards-contract.d.ts
+++ b/typings/fees-and-bootstrap-rewards-contract.d.ts
@@ -95,7 +95,8 @@ export interface FeesAndBootstrapRewardsContract extends OwnedContract {
         bootstrapBalance: string,
         lastBootstrapPerMember: string,
         withdrawnFees: string,
-        withdrawnBootstrap: string
+        withdrawnBootstrap: string,
+        certified: bool
     }>;
 
     estimateFutureFeesAndBootstrapRewards(guardian: string, duration: number): Promise<{estimatedFees: number, estimatedBootstrapRewards: number}>;

--- a/typings/fees-and-bootstrap-rewards-contract.d.ts
+++ b/typings/fees-and-bootstrap-rewards-contract.d.ts
@@ -5,21 +5,29 @@ import {OwnedContract} from "./base-contract";
 export interface FeesAssignedEvent {
     guardian: string,
     amount: (string|BN),
+    totalAwarded: (string|BN),
+    certification: boolean,
+    feesPerMember: (string|BN)
 }
 
 export interface BootstrapRewardsAssignedEvent {
     guardian: string,
     amount: (string|BN),
+    totalAwarded: (string|BN),
+    certification: boolean,
+    bootstrapPerMember: (string|BN)
 }
 
 export interface FeesWithdrawnEvent {
     guardian: string,
     amount: (string|BN),
+    totalWithdrawn: (string|BN)
 }
 
 export interface BootstrapRewardsWithdrawnEvent {
     guardian: string,
-    amount: string|BN
+    amount: string|BN,
+    totalWithdrawn: (string|BN)
 }
 
 export interface FeesAndBootstrapRewardsBalanceMigratedEvent {
@@ -81,7 +89,14 @@ export interface FeesAndBootstrapRewardsContract extends OwnedContract {
     // fees
     withdrawFees(guardian: string, params?: TransactionConfig): Promise<TransactionReceipt>;
     getFeesAndBootstrapBalance(address: string): Promise<{feeBalance: string, bootstrapBalance: string}>;
-    getFeesAndBootstrapData(address: string): Promise<{feeBalance: string, lastFeesPerMember:string, bootstrapBalance: string, lastBootstrapPerMember: string}>;
+    getFeesAndBootstrapData(address: string): Promise<{
+        feeBalance: string,
+        lastFeesPerMember:string,
+        bootstrapBalance: string,
+        lastBootstrapPerMember: string,
+        withdrawnFees: string,
+        withdrawnBootstrap: string
+    }>;
 
     estimateFutureFeesAndBootstrapRewards(guardian: string, duration: number): Promise<{estimatedFees: number, estimatedBootstrapRewards: number}>;
 

--- a/typings/staking-rewards-contract.d.ts
+++ b/typings/staking-rewards-contract.d.ts
@@ -12,6 +12,7 @@ export interface GuardianStakingRewardsAssignedEvent {
     amount: (string|BN),
     totalAwarded: (string|BN),
     delegatorRewardsPerToken: (string|BN),
+    weightInCommittee: (string|BN),
     stakingRewardsPerWeight: (string|BN)
 }
 
@@ -20,6 +21,7 @@ export interface DelegatorStakingRewardsAssignedEvent {
     amount: (string|BN),
     totalAwarded: (string|BN),
     guardian: string,
+    stake: (string|BN),
     delegatorRewardsPerToken: (string|BN)
 }
 
@@ -100,8 +102,10 @@ export interface StakingRewardsContract extends OwnedContract {
 
     getGuardianStakingRewardsData(guardian: string, params?: TransactionConfig): Promise<{
         balance: string,
+        claimed: string,
         delegatorRewardsPerToken: string,
-        lastStakingRewardsPerWeight: string
+        lastStakingRewardsPerWeight: string,
+        weightInCommittee: string
     }>;
 
     guardiansStakingRewards(guardian: string, params?: TransactionConfig): Promise<{
@@ -112,7 +116,10 @@ export interface StakingRewardsContract extends OwnedContract {
 
     getDelegatorStakingRewardsData(delegator: string, params?: TransactionConfig): Promise<{
         balance: string,
-        lastDelegatorRewardsPerToken: string
+        claimed: string,
+        lastDelegatorRewardsPerToken: string,
+        guardian: string,
+        stake: string
     }>;
 
     delegatorsStakingRewards(delegator: string, params?: TransactionConfig): Promise<{

--- a/typings/staking-rewards-contract.d.ts
+++ b/typings/staking-rewards-contract.d.ts
@@ -11,9 +11,10 @@ export interface GuardianStakingRewardsAssignedEvent {
     guardian: string,
     amount: (string|BN),
     totalAwarded: (string|BN),
+    stakingRewardsPerWeight: (string|BN),
     delegatorRewardsPerToken: (string|BN),
-    weightInCommittee: (string|BN),
-    stakingRewardsPerWeight: (string|BN)
+    stakingRewardsPerWeightDelta: (string|BN),
+    delegatorRewardsPerTokenDelta: (string|BN)
 }
 
 export interface DelegatorStakingRewardsAssignedEvent {
@@ -21,8 +22,8 @@ export interface DelegatorStakingRewardsAssignedEvent {
     amount: (string|BN),
     totalAwarded: (string|BN),
     guardian: string,
-    stake: (string|BN),
-    delegatorRewardsPerToken: (string|BN)
+    delegatorRewardsPerToken: (string|BN),
+    delegatorRewardsPerTokenDelta: (string|BN)
 }
 
 export interface DefaultDelegatorsStakingRewardsChangedEvent {
@@ -104,8 +105,9 @@ export interface StakingRewardsContract extends OwnedContract {
         balance: string,
         claimed: string,
         delegatorRewardsPerToken: string,
+        delegatorRewardsPerTokenDelta: string,
         lastStakingRewardsPerWeight: string,
-        weightInCommittee: string
+        stakingRewardsPerWeightDelta: string
     }>;
 
     guardiansStakingRewards(guardian: string, params?: TransactionConfig): Promise<{
@@ -118,8 +120,8 @@ export interface StakingRewardsContract extends OwnedContract {
         balance: string,
         claimed: string,
         lastDelegatorRewardsPerToken: string,
+        delegatorRewardsPerTokenDelta: string,
         guardian: string,
-        stake: string
     }>;
 
     delegatorsStakingRewards(delegator: string, params?: TransactionConfig): Promise<{


### PR DESCRIPTION
- Added `withdrawnFees`, `withdrawenBootstrap`. Emitting `totalAwarded` in assignment events and `totalWithdrawn` in withdraw events.
- Adding `feesPerMember`, `bootstrapPerMember`, `certification` to assignment events
- Added `totalClaimed` and certification to `getFeesAndBootstrapData`
- Added `stake` to `delegatorStakingRewardsAssigned events`